### PR TITLE
DeepDocGoogleDriveAction

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = __jac_gen__, .git, __pycache__, venv
+plugins = flake8_docstrings, flake8_comprehensions, flake8_bugbear, flake8_annotations, pep8_naming, flake8_simplify
+max-line-length = 120
+ignore = E203, W503, ANN101, ANN102, D205, D400, D401, D202, E501

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to report any bugs in the jivas PolicyAction.
+title: "[BUG]: "
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - Python Version [e.g. 3.12]
+ - Jaclang Version [e.g. 0.7.27]
+ - Jivas Version [e.g. 2.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for the jivas PolicyAction.
+title: "[Feature Request]: "
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/refactor-request.md
+++ b/.github/ISSUE_TEMPLATE/refactor-request.md
@@ -1,0 +1,40 @@
+---
+name: Refactor Request
+about: Request a refactor to the jivas PolicyAction.
+title: "[Refactor Request]: "
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+Provide a brief description of the refactor you are proposing. Focus on the high-level goal of the change.
+
+## Current Problem
+Describe the current issues with the existing code. Examples:
+- Poor readability or maintainability
+- Duplication of code
+- Performance bottlenecks
+- Lack of extensibility
+
+## Proposed Solution
+Explain the refactor you are suggesting:
+- Outline how the code will be reorganized, improved, or optimized.
+- Specify any best practices or patterns you aim to implement.
+- Highlight tools, libraries, or approaches you plan to leverage.
+
+## Expected Benefits
+Describe the outcomes and benefits of this refactor:
+- Enhanced code quality
+- Improved maintainability
+- Better performance
+- Simplified debugging or testing
+
+## Scope of Changes
+List the modules, files, or components that are likely to be impacted:
+- [ ] Module/File 1
+- [ ] Module/File 2
+- [ ] Component 3
+
+## Additional Notes
+Include any additional context or examples that will help clarify the refactor. Add links to related issues, discussions, or documentation, if applicable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,76 @@
+## **Type of Change**
+What type of change does this PR introduce? Mark all that apply:
+- [ ] 🐛 Bug Fix
+- [ ] 🚀 Feature Request
+- [ ] 🔄 Refactor
+- [ ] 📖 Documentation Update
+- [ ] 🔧 Other (Please specify):
+
+---
+
+## **Summary**
+### **What does this PR address?**
+Provide a concise summary of the changes introduced in this pull request. Specify if it resolves an issue, adds a feature, or refactors code.
+
+For example:
+- Resolves #ISSUE_ID
+- Adds feature for X
+- Refactors Y to improve Z
+
+---
+
+## **Description**
+### **Bug Fixes**:
+If this PR fixes a bug, please provide:
+- A brief description of the bug.
+- The root cause of the issue.
+- How this PR resolves the issue.
+
+### **Feature Request**:
+If this PR adds a new feature, please provide:
+- A brief description of the feature.
+- The motivation for introducing it.
+- Any relevant details about implementation.
+
+### **Refactor Request**:
+If this PR refactors code, please provide:
+- The specific area of code refactored.
+- The problem with the current implementation.
+- The improvements made in the refactor.
+
+---
+
+## **Changes Made**
+### High-Level Summary:
+List the key changes made in this PR:
+1. Change 1
+2. Change 2
+3. Change 3
+
+---
+
+## **Checklist**
+Mark all that apply:
+- [ ] Code follows the project’s coding guidelines.
+- [ ] Tests have been added or updated for new functionality.
+- [ ] Documentation has been updated (if applicable).
+- [ ] Existing tests pass locally with these changes.
+- [ ] Any dependencies introduced are justified and documented.
+
+---
+
+## **Steps to Test**
+Provide a clear set of steps for testing the changes introduced in this PR:
+1. Step 1
+2. Step 2
+3. Step 3
+
+---
+
+## **Additional Context**
+If necessary, provide additional context, screenshots, or relevant references for the changes in this PR.
+
+---
+
+## **Questions or Concerns**
+Are there any open questions or areas of concern related to this PR? If so, mention them here.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 🚀 Features | Bug Fixes 🐛 | Refactor 🔄
+      labels:
+        - '*'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,32 @@
+name: Linting and Pre-commit checks for jivas PolicyAction
+
+on:
+  pull_request:
+    paths:
+      - "policy_action/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "policy_action/**"
+
+jobs:
+  pre-commit-jaclang:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.12
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit hooks
+      run: pre-commit run --files $(find . -type f)

--- a/.github/workflows/release-action.yaml
+++ b/.github/workflows/release-action.yaml
@@ -1,0 +1,88 @@
+name: Release Action to Jivas Package Registry
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  check-version:
+    name: Check Package Version
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.check.outputs.version_changed }}
+      new_version: ${{ steps.check.outputs.new_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get previous version from Git tags
+        id: get_previous_version
+        run: |
+          git fetch --tags
+          VERSION_TAG=$(git tag --list "v*" --sort=-v:refname | head -n 1 | sed 's/^v//')
+          echo "previous_version=${VERSION_TAG:-0.0.0}" >> $GITHUB_ENV
+          echo "Previous version: $VERSION_TAG"
+          echo "previous_version=${VERSION_TAG:-0.0.0}" >> $GITHUB_OUTPUT
+
+      - name: Get new version from info.yaml
+        id: check
+        run: |
+          NEW_VERSION=$(grep -oP '(?<=^  version: )\d+\.\d+\.\d+' policy_action/info.yaml)
+          echo "Detected package version: $NEW_VERSION"
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_ENV
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+          if [ "$NEW_VERSION" == "${{ env.previous_version }}" ]; then
+            echo "Version has not changed."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version has changed."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+          fi
+
+  publish:
+    name: Publish Action & Create Release
+    if: ${{ needs.check-version.outputs.version_changed }} == 'true'
+    needs: check-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+
+      - name: Install Jivas CLI
+        run: pip install jvcli
+
+      - name: Publish to Jivas Package Registry
+        run: |
+          echo "Publishing new version to Jivas Package Registry..."
+          jvcli login --username ${{ secrets.JPR_ADMIN_USERNAME }} --password ${{ secrets.JPR_ADMIN_PASSWORD }}
+          jvcli publish action --path policy_action --visibility public
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "admin@trueselph.com"
+          git config --global user.name "TrueSelph Inc."
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Creating GitHub release..."
+          VERSION=${{ needs.check-version.outputs.new_version }}
+          git tag -a "v$VERSION" -m "Release version $VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" --title "Release version $VERSION" --notes "Release version $VERSION" --generate-notes
+          echo "Release created successfully."

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -1,0 +1,27 @@
+name: Running tests for jivas PolicyAction
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.12
+
+    - name: Install dependencies
+      run: pip install jivas[dev]
+
+    # - name: Run tests
+    #   run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Jaclang #
+*.pyc
+__pycache__
+venv
+__jac_gen__/
+*.jir
+
+# Distribution / packaging
+.Python
+play/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Others #
+.coverage
+.session
+*.session.db
+.DS_Store
+.vscode
+build
+*Zone.Identifier
+.DS_Store
+parser.out
+codegen_output*
+
+*.rdb
+node_modules
+out.dot
+out.txt
+
+# Mypy files #
+.mypy_cache*
+.jac_mypy_cache*
+
+
+# Jaclang session files
+*.session

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,57 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: trailing-whitespace
+
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        exclude: "^(venv|__jac_gen__)/"
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        exclude: "^(venv|__jac_gen__)/"
+        args: ["--profile", "black"]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.2
+    hooks:
+      - id: flake8
+        args: ["--config=.flake8"]
+        additional_dependencies:
+          - pep8-naming
+          - flake8_docstrings
+          - flake8_comprehensions
+          - flake8_bugbear
+          - flake8_annotations
+          - flake8_simplify
+        exclude: "^(venv|__jac_gen__)/"
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        exclude: "^(venv|__jac_gen__)/"
+        args:
+          - --follow-imports=silent
+          - --ignore-missing-imports
+          - --explicit-package-bases
+        additional_dependencies:
+          - types-PyYAML
+          - types-requests
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        name: Detect Secrets
+        args: ['scan', '.']
+        files: \.(py|jac|txt|yaml|json)$  # Extend this regex if needed
+        exclude: "^(venv|__jac_gen__|.mypy_cache|.jac_mypy_cache)/"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# DeepDoc Google Drive Integration Action (with Watcher)
+
+## Package Information
+
+- **Name:** jivas/deepdoc_google_drive_action
+- **Author:** AA
+- **Architype:** DeepDocGoogleDriveAction
+- **Version:** 0.0.3
+
+## Meta Information
+
+- **Title:** DeepDoc Google Drive Integration Action (with Watcher)
+- **Description:** Ingests, manages, and watches documents/folders from Google Drive using the DeepDoc client for vector storage and processing. Automatically reacts to changes in watched Google Drive resources.
+- **Group:** integration
+- **Type:** action
+
+## Features (Version 0.0.3)
+
+- **Google Drive Document Ingestion:**
+  - Ingests individual files or all files within specified Google Drive folders.
+  - Downloads content and queues it to a configured `DeepDocClientAction` for processing and vector storage.
+  - Stores Google Drive metadata (file ID, folder ID, filename, MIME type) with the document in DeepDoc, ensuring correct folder association even for webhook-triggered re-ingestions.
+- **Google Drive Watcher (Push Notifications):**
+  - **Start/Stop Watching:** Allows starting and stopping watches on specific Google Drive files or folders.
+    - **Corrected Watcher Logic (v0.0.3):** Ensures that when ingesting a folder (either initially or due to a webhook for a watched folder), a single watch is correctly established on the *folder itself*, rather than creating multiple watchers for individual files within it.
+  - **Webhook Receiver:** Includes `gdrive_notification_receiver_walker` to handle incoming change notifications from Google Drive.
+  - **Automatic Re-ingestion/Deletion:**
+    - On "change" notification for a watched resource, automatically re-ingests the updated file/folder contents into DeepDoc.
+    - On "trash" or "remove" notification, automatically removes the corresponding document(s) from DeepDoc and stops the watch if appropriate.
+  - **Channel Renewal:** A `pulse` ability, schedulable via `PulseAction`, automatically renews active watch channels before they expire.
+  - **Watch Recovery:** An `on_enable` hook and `recover_watches` ability attempt to re-establish watches for resources listed in the DAF configuration (`watched_gdrive_resources`) after an agent restart.
+- **Vector Store Management:**
+  - Remove individual Google Drive files or entire folders (and their contents) from the DeepDoc vector store, including managing associated watchers.
+- **Configuration & UI:**
+  - Configurable via agent DAF for Google Cloud Service Account credentials, DeepDoc action label, default GDrive folder, and comprehensive watcher settings.
+  - Streamlit UI (`app/app.py`) for:
+    - Managing Google Drive credentials.
+    - Triggering manual ingestion.
+    - Managing Google Drive watchers (start, stop, list active, trigger manual renewal/recovery).
+    - Viewing and managing documents ingested from Google Drive (via DeepDoc's manifest).
+
+## Configuration (To be set in Agent DAF context for this action)
+
+- **`watched_gdrive_resources`** (List[Dict], default: `[]`):
+  - A list of Google Drive resources that the action should persistently try to watch.
+  - Each item is a dictionary, e.g., `{"gdrive_id": "your_folder_or_file_id", "type": "folder"}`. The `type` field ("file" or "folder") is now used by the watcher logic to determine how to watch the resource.
+- **`default_webhook_base_url`** (str, default: `""` or `JIVAS_BASE_URL` env var):
+  - Your Jiva instance's publicly accessible base URL (e.g., `https://my-jiva.example.com`). **Crucial for Google Drive to send notifications.**
+- **`auto_watch_on_ingest`** (bool, default: `true`):
+  - Whether to automatically attempt to start watching a GDrive resource after it has been ingested.
+- **`pulse_interval_seconds`** (int, default: `3600`):
+  - How often the `pulse` ability runs to check and renew watch channels.
+- **`renew_threshold_hours`** (int, default: `6`):
+  - If a watch channel's expiration is within this many hours, it will be renewed.
+- **`default_folder_id`** (str, optional): Default Google Drive folder ID for operations if not specified.
+- **`deepdoc_action_label`** (str, default: `"DeepDocClientAction"`): Label of the `DeepDocClientAction` used.
+- **`scopes`** (list, default: `["https://www.googleapis.com/auth/drive.readonly"]`): Google API scopes.
+- **Service Account Credentials:** (All string values, `private_key` is multiline)
+  - `project_id`, `private_key_id`, `private_key`, `client_email`, `client_id`, `auth_uri`, `token_uri`, `auth_provider_x509_cert_url`, `client_x509_cert_url`, `universe_domain`.
+
+## Core Abilities (Callable via Walkers or Internally)
+
+- **`ingest_drive_items(drive_ids: List[str], item_type: str, user_metadata: Optional[Dict])`**: Ingests from GDrive to DeepDoc and manages `auto_watch_on_ingest`.
+- **`remove_drive_item_from_vector_store(google_drive_file_id: str)`**: Removes a GDrive file from DeepDoc and its watch.
+- **`remove_drive_folder_from_vector_store(google_drive_folder_id: str)`**: Removes GDrive folder contents from DeepDoc and its watch.
+- **`start_watching_resource(gdrive_resource_id: str, resource_type: str, webhook_base_url: Optional[str])`**: Starts a new watch (for "file" or "folder").
+- **`stop_watching_resource(jiva_channel_uuid: str, initiated_by_user: bool)`**: Stops an active watch.
+- **`renew_watch_channel(jiva_channel_uuid: str)`**: Manually triggers renewal of a watch.
+- **`list_active_watches()`**: Returns a list of Jiva-managed active watches.
+- **`process_drive_notification(headers: Dict, body_str: str)`**: Handles GDrive webhook events.
+- **`pulse()`**: Scheduled ability to renew watch channels.
+- **`recover_watches(webhook_base_url: Optional[str])`**: Re-establishes watches from DAF config.
+- **`healthcheck()`**: Checks GDrive/DeepDoc/Webhook URL connectivity.
+- **UI Helpers:** `list_gdrive_folder_contents`, `get_ingested_documents_from_drive`.
+
+## Walkers
+
+- **`gdrive_notification_receiver_walker`**: Webhook endpoint for Google Drive push notifications.
+- **`manage_gdrive_watch_walker`**: UI walker to start/stop/list/renew/recover watches.
+- (Existing walkers for ingestion and direct management: `ingest_gdrive_items_walker`, `remove_gdrive_item_walker`, `clear_gdrive_folder_walker`, `list_gdrive_folder_contents_walker`, `get_ingested_gdrive_docs_walker`).
+
+## Dependencies
+
+- **Jiva Actions:**
+  - `jivas/deepdoc_client_action`: For interacting with the DeepDoc service.
+  - `jivas/pulse_action`: For scheduling the watch renewal `pulse`.
+- **Python Libraries:**
+  - `google-api-python-client` (>=2.80.0 recommended)
+  - `google-auth` (>=2.14.0 recommended)
+  - `google-auth-httplib2` (>=0.1.0 recommended)
+  - (Ensure these are in the Jiva environment's `requirements.txt` or specified in the action's `info.yaml` pip dependencies).
+
+## Setup Notes
+
+1.  **Google Cloud Project:** Ensure the Google Drive API is enabled.
+2.  **Service Account:** Create and download a Service Account key JSON. Configure credentials in the agent's DAF for this action.
+3.  **Public Jiva URL:** The `default_webhook_base_url` (or `JIVAS_BASE_URL` env var) **must** point to your publicly accessible Jiva instance for Google to send notifications.
+4.  **DAF Configuration:**
+    - Populate all Google Service Account credentials.
+    - Set `default_webhook_base_url`.
+    - Configure `watched_gdrive_resources` with resources (and their `type`: "file" or "folder") to monitor automatically upon agent startup. Example: `{"gdrive_id": "your_id", "type": "folder"}`.
+5.  **Dependent Actions:** Ensure `DeepDocClientAction` and `PulseAction` are correctly configured and enabled for the agent.
+6.  **Google Drive Changes API:** This action now utilizes the `changes().watch()` and `files().watch()` API for push notifications. The `page_token` for `changes` API is managed internally to process changes since the last notification.

--- a/deepdoc_google_drive_action/CHANGELOG.md
+++ b/deepdoc_google_drive_action/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+## 0.0.3 - Refined Watcher Logic & Stability
+
+- **Fixes:**
+  - **Corrected Watcher Creation for Initial Folder Ingestion:** Resolved an issue where ingesting a folder with `auto_watch_on_ingest: true` would incorrectly attempt to create individual file watchers for each item in the folder. The logic now correctly identifies that the ingestion was for a folder and establishes a single watch on the parent folder ID itself, preventing multiple redundant file watchers. This was due to a key mismatch when checking the context of the ingestion trigger within the `ingest_drive_items` ability.
+  - Ensured `default_webhook_base_url` is consistently initialized and used, including fallback to `JIVAS_BASE_URL` environment variable during `on_enable` and subsequent operations if not set in DAF.
+  - Corrected usage of `self.get_label()` when interacting with `PulseAction` for scheduling `pulse` ability, ensuring the correct action instance is targeted.
+- **Improvements:**
+  - Added more specific logging within the watcher creation logic in `ingest_drive_items` to clarify whether a file watch or folder watch is being initiated based on the ingestion context.
+  - Clarified logic in `start_watching_resource` to check for existing watches on the *exact* GDrive resource ID and *type* (file/folder) before creating a new one, further preventing duplicates.
+  - Refined parameter passing for `resource_type` in `start_watching_resource` and `renew_watch_channel` to ensure consistency.
+  - Minor improvements to logging messages for clarity in watch management and notification processing.
+- **Chores:**
+  - General code cleanup and comment consistency.
+
+## 0.0.2 - GDrive Watcher & Enhanced Management
+
+- **New Features:**
+  - Implemented Google Drive Push Notifications (Watcher) for files.
+    - Action can now start/stop watches on GDrive resources.
+    - Added `gdrive_notification_receiver_walker` to process incoming change notifications from Google Drive.
+    - Notifications for "change" trigger re-ingestion into DeepDoc.
+    - Notifications for "trash" or "remove" trigger deletion from DeepDoc and stop the watch.
+  - Automatic Watch Channel Renewal:
+    - Added `pulse` ability, schedulable via `PulseAction`.
+    - `pulse` periodically checks active watch channels and renews them before expiration.
+  - Watch Recovery:
+    - Added `recover_watches` ability, typically called on action `on_enable`.
+    - Attempts to re-establish watches for resources defined in DAF config (`watched_gdrive_resources`).
+  - Persistent "Intended Watches":
+    - New DAF configuration `watched_gdrive_resources` (list of GDrive IDs) to specify which resources should be monitored persistently.
+  - Webhook Base URL Configuration:
+    - Added `default_webhook_base_url` DAF configuration.
+    - Action falls back to `JIVAS_BASE_URL` environment variable if DAF config is not set.
+  - Enhanced UI Walkers & App:
+    - Added `manage_gdrive_watch_walker` for UI to start, stop, list, and manually renew/recover watches.
+    - Updated `app/app.py` with sections to manage watchers, view active watches, and trigger watch operations.
+- **Improvements:**
+  - Refined `PulseAction` integration for scheduling the `pulse` ability using `self.get_label()`.
+  - Improved logging for watch management and notification processing.
+  - `on_enable` now attempts to recover watches and start the pulse scheduler.
+  - `on_disable` now stops the pulse scheduler and attempts to clean up active Google Drive watch channels.
+  - `healthcheck` ability updated slightly to be aware of webhook URL configuration needs.
+- **Fixes:**
+  - Corrected Jaclang syntax for block scoping (`{}`) and statement termination (`;`).
+  - Ensured correct usage of `#` for comments in Jaclang code.
+  - Corrected relative import paths for Python modules within the action.
+
+## 0.0.1 - Initial Release
+
+- **Features:**
+  - Core integration with Google Drive for document ingestion.
+    - `GoogleDriveHandler` Python module for API interactions (list files, get metadata, download content).
+    - Service Account authentication for Google Drive.
+  - Integration with `DeepDocClientAction` for document processing and vector storage.
+    - `ingest_drive_items` ability to download from GDrive and queue to DeepDoc.
+    - `remove_drive_item_from_vector_store` ability to remove GDrive-originated items from DeepDoc.
+    - `remove_drive_folder_from_vector_store` ability.
+  - Basic UI Walkers:
+    - `ingest_gdrive_items_walker`
+    - `remove_gdrive_item_walker`
+    - `clear_gdrive_folder_walker`
+    - `list_gdrive_folder_contents_walker`
+    - `get_ingested_gdrive_docs_walker`
+  - Streamlit UI (`app/app.py`) for:
+    - Configuring Google Drive credentials.
+    - Triggering ingestion of files/folders.
+    - Listing and managing ingested documents (from DeepDoc manifest).
+  - `healthcheck` ability for basic GDrive and DeepDoc connectivity.
+  - DAF configurable Google Drive credentials and DeepDoc action label.

--- a/deepdoc_google_drive_action/README.md
+++ b/deepdoc_google_drive_action/README.md
@@ -1,0 +1,103 @@
+# DeepDoc Google Drive Integration Action (with Watcher)
+
+## Package Information
+
+- **Name:** jivas/deepdoc_google_drive_action
+- **Author:** AA
+- **Architype:** DeepDocGoogleDriveAction
+- **Version:** 0.0.3
+
+## Meta Information
+
+- **Title:** DeepDoc Google Drive Integration Action (with Watcher)
+- **Description:** Ingests, manages, and watches documents/folders from Google Drive using the DeepDoc client for vector storage and processing. Automatically reacts to changes in watched Google Drive resources.
+- **Group:** integration
+- **Type:** action
+
+## Features (Version 0.0.3)
+
+- **Google Drive Document Ingestion:**
+  - Ingests individual files or all files within specified Google Drive folders.
+  - Downloads content and queues it to a configured `DeepDocClientAction` for processing and vector storage.
+  - Stores Google Drive metadata (file ID, folder ID, filename, MIME type) with the document in DeepDoc, ensuring correct folder association even for webhook-triggered re-ingestions.
+- **Google Drive Watcher (Push Notifications):**
+  - **Start/Stop Watching:** Allows starting and stopping watches on specific Google Drive files or folders.
+    - **Corrected Watcher Logic (v0.0.3):** Ensures that when ingesting a folder (either initially or due to a webhook for a watched folder), a single watch is correctly established on the *folder itself*, rather than creating multiple watchers for individual files within it.
+  - **Webhook Receiver:** Includes `gdrive_notification_receiver_walker` to handle incoming change notifications from Google Drive.
+  - **Automatic Re-ingestion/Deletion:**
+    - On "change" notification for a watched resource, automatically re-ingests the updated file/folder contents into DeepDoc.
+    - On "trash" or "remove" notification, automatically removes the corresponding document(s) from DeepDoc and stops the watch if appropriate.
+  - **Channel Renewal:** A `pulse` ability, schedulable via `PulseAction`, automatically renews active watch channels before they expire.
+  - **Watch Recovery:** An `on_enable` hook and `recover_watches` ability attempt to re-establish watches for resources listed in the DAF configuration (`watched_gdrive_resources`) after an agent restart.
+- **Vector Store Management:**
+  - Remove individual Google Drive files or entire folders (and their contents) from the DeepDoc vector store, including managing associated watchers.
+- **Configuration & UI:**
+  - Configurable via agent DAF for Google Cloud Service Account credentials, DeepDoc action label, default GDrive folder, and comprehensive watcher settings.
+  - Streamlit UI (`app/app.py`) for:
+    - Managing Google Drive credentials.
+    - Triggering manual ingestion.
+    - Managing Google Drive watchers (start, stop, list active, trigger manual renewal/recovery).
+    - Viewing and managing documents ingested from Google Drive (via DeepDoc's manifest).
+
+## Configuration (To be set in Agent DAF context for this action)
+
+- **`watched_gdrive_resources`** (List[Dict], default: `[]`):
+  - A list of Google Drive resources that the action should persistently try to watch.
+  - Each item is a dictionary, e.g., `{"gdrive_id": "your_folder_or_file_id", "type": "folder"}`. The `type` field ("file" or "folder") is now used by the watcher logic to determine how to watch the resource.
+- **`default_webhook_base_url`** (str, default: `""` or `JIVAS_BASE_URL` env var):
+  - Your Jiva instance's publicly accessible base URL (e.g., `https://my-jiva.example.com`). **Crucial for Google Drive to send notifications.**
+- **`auto_watch_on_ingest`** (bool, default: `true`):
+  - Whether to automatically attempt to start watching a GDrive resource after it has been ingested.
+- **`pulse_interval_seconds`** (int, default: `3600`):
+  - How often the `pulse` ability runs to check and renew watch channels.
+- **`renew_threshold_hours`** (int, default: `6`):
+  - If a watch channel's expiration is within this many hours, it will be renewed.
+- **`default_folder_id`** (str, optional): Default Google Drive folder ID for operations if not specified.
+- **`deepdoc_action_label`** (str, default: `"DeepDocClientAction"`): Label of the `DeepDocClientAction` used.
+- **`scopes`** (list, default: `["https://www.googleapis.com/auth/drive.readonly"]`): Google API scopes.
+- **Service Account Credentials:** (All string values, `private_key` is multiline)
+  - `project_id`, `private_key_id`, `private_key`, `client_email`, `client_id`, `auth_uri`, `token_uri`, `auth_provider_x509_cert_url`, `client_x509_cert_url`, `universe_domain`.
+
+## Core Abilities (Callable via Walkers or Internally)
+
+- **`ingest_drive_items(drive_ids: List[str], item_type: str, user_metadata: Optional[Dict])`**: Ingests from GDrive to DeepDoc and manages `auto_watch_on_ingest`.
+- **`remove_drive_item_from_vector_store(google_drive_file_id: str)`**: Removes a GDrive file from DeepDoc and its watch.
+- **`remove_drive_folder_from_vector_store(google_drive_folder_id: str)`**: Removes GDrive folder contents from DeepDoc and its watch.
+- **`start_watching_resource(gdrive_resource_id: str, resource_type: str, webhook_base_url: Optional[str])`**: Starts a new watch (for "file" or "folder").
+- **`stop_watching_resource(jiva_channel_uuid: str, initiated_by_user: bool)`**: Stops an active watch.
+- **`renew_watch_channel(jiva_channel_uuid: str)`**: Manually triggers renewal of a watch.
+- **`list_active_watches()`**: Returns a list of Jiva-managed active watches.
+- **`process_drive_notification(headers: Dict, body_str: str)`**: Handles GDrive webhook events.
+- **`pulse()`**: Scheduled ability to renew watch channels.
+- **`recover_watches(webhook_base_url: Optional[str])`**: Re-establishes watches from DAF config.
+- **`healthcheck()`**: Checks GDrive/DeepDoc/Webhook URL connectivity.
+- **UI Helpers:** `list_gdrive_folder_contents`, `get_ingested_documents_from_drive`.
+
+## Walkers
+
+- **`gdrive_notification_receiver_walker`**: Webhook endpoint for Google Drive push notifications.
+- **`manage_gdrive_watch_walker`**: UI walker to start/stop/list/renew/recover watches.
+- (Existing walkers for ingestion and direct management: `ingest_gdrive_items_walker`, `remove_gdrive_item_walker`, `clear_gdrive_folder_walker`, `list_gdrive_folder_contents_walker`, `get_ingested_gdrive_docs_walker`).
+
+## Dependencies
+
+- **Jiva Actions:**
+  - `jivas/deepdoc_client_action`: For interacting with the DeepDoc service.
+  - `jivas/pulse_action`: For scheduling the watch renewal `pulse`.
+- **Python Libraries:**
+  - `google-api-python-client` (>=2.80.0 recommended)
+  - `google-auth` (>=2.14.0 recommended)
+  - `google-auth-httplib2` (>=0.1.0 recommended)
+  - (Ensure these are in the Jiva environment's `requirements.txt` or specified in the action's `info.yaml` pip dependencies).
+
+## Setup Notes
+
+1.  **Google Cloud Project:** Ensure the Google Drive API is enabled.
+2.  **Service Account:** Create and download a Service Account key JSON. Configure credentials in the agent's DAF for this action.
+3.  **Public Jiva URL:** The `default_webhook_base_url` (or `JIVAS_BASE_URL` env var) **must** point to your publicly accessible Jiva instance for Google to send notifications.
+4.  **DAF Configuration:**
+    - Populate all Google Service Account credentials.
+    - Set `default_webhook_base_url`.
+    - Configure `watched_gdrive_resources` with resources (and their `type`: "file" or "folder") to monitor automatically upon agent startup. Example: `{"gdrive_id": "your_id", "type": "folder"}`.
+5.  **Dependent Actions:** Ensure `DeepDocClientAction` and `PulseAction` are correctly configured and enabled for the agent.
+6.  **Google Drive Changes API:** This action now utilizes the `changes().watch()` and `files().watch()` API for push notifications. The `page_token` for `changes` API is managed internally to process changes since the last notification.

--- a/deepdoc_google_drive_action/app/app.py
+++ b/deepdoc_google_drive_action/app/app.py
@@ -1,0 +1,753 @@
+"""DeepDoc Google Drive Action App"""
+
+import json
+import math
+
+import streamlit as st
+from jvcli.client.lib.utils import (
+    call_action_walker_exec,  # Only this one is needed now
+)
+from jvcli.client.lib.widgets import app_header, app_update_action
+
+
+# --- Helper Functions (keep as is) ---
+def get_gdrive_action_config_keys() -> list:
+    """Get the keys for Google Drive action configuration"""
+
+    return [
+        "default_folder_id",
+        "deepdoc_action_label",
+        "project_id",
+        "private_key_id",
+        "private_key",
+        "client_email",
+        "client_id",
+        "auth_uri",
+        "token_uri",
+        "auth_provider_x509_cert_url",
+        "client_x509_cert_url",
+        "universe_domain",
+    ]
+
+
+def load_config_from_json(model_key: str) -> None:
+    """Load service account credentials from a JSON file"""
+    uploaded_file = st.file_uploader(
+        "Upload Service Account JSON", type="json", key=f"{model_key}_sa_json"
+    )
+    if uploaded_file is not None:
+        try:
+            creds_data = json.load(uploaded_file)
+            st.session_state[model_key]["project_id"] = creds_data.get("project_id", "")
+            st.session_state[model_key]["private_key_id"] = creds_data.get(
+                "private_key_id", ""
+            )
+            st.session_state[model_key]["private_key"] = creds_data.get(
+                "private_key", ""
+            ).replace("\n", "\\n")
+            st.session_state[model_key]["client_email"] = creds_data.get(
+                "client_email", ""
+            )
+            st.session_state[model_key]["client_id"] = creds_data.get("client_id", "")
+            st.session_state[model_key]["auth_uri"] = creds_data.get(
+                "auth_uri", "https://accounts.google.com/o/oauth2/auth"
+            )
+            st.session_state[model_key]["token_uri"] = creds_data.get(
+                "token_uri", "https://oauth2.googleapis.com/token"
+            )
+            st.session_state[model_key]["auth_provider_x509_cert_url"] = creds_data.get(
+                "auth_provider_x509_cert_url",
+                "https://www.googleapis.com/oauth2/v1/certs",
+            )
+            st.session_state[model_key]["client_x509_cert_url"] = creds_data.get(
+                "client_x509_cert_url", ""
+            )
+            st.session_state[model_key]["universe_domain"] = creds_data.get(
+                "universe_domain", "googleapis.com"
+            )
+            st.success("Service account credentials loaded from JSON.")
+            st.rerun()
+        except Exception as e:
+            st.error(f"Error loading service account JSON: {e}")
+
+
+def render(
+    router: st.delta_generator.DeltaGenerator, agent_id: str, action_id: str, info: dict
+) -> None:
+    """Render the Google Drive action app"""
+
+    (model_key, module_root) = app_header(agent_id, action_id, info)
+
+    if "gdrive_folder_to_ingest" not in st.session_state:
+        st.session_state.gdrive_folder_to_ingest = st.session_state[model_key].get(
+            "default_folder_id", ""
+        )
+    if "gdrive_files_to_ingest" not in st.session_state:
+        st.session_state.gdrive_files_to_ingest = ""
+    if (
+        "gdrive_watch_resource_type" not in st.session_state
+    ):  # Add new session state for resource type
+        st.session_state.gdrive_watch_resource_type = "file"
+    if "gdrive_watch_resource_id" not in st.session_state:
+        st.session_state.gdrive_watch_resource_id = ""
+    if "gdrive_jiva_channel_uuid_to_stop" not in st.session_state:
+        st.session_state.gdrive_jiva_channel_uuid_to_stop = ""
+    if f"{model_key}_active_watches_cache" not in st.session_state:
+        st.session_state[f"{model_key}_active_watches_cache"] = (
+            None  # For caching list response
+        )
+    # ... (other session state initializations)
+
+    with st.expander("Google Drive & DeepDoc Configuration", expanded=False):
+        st.subheader("Service Account Credentials")
+        load_config_from_json(model_key)
+        st.session_state[model_key]["project_id"] = st.text_input(
+            "Project ID", value=st.session_state[model_key].get("project_id", "")
+        )
+        st.session_state[model_key]["client_email"] = st.text_input(
+            "Client Email", value=st.session_state[model_key].get("client_email", "")
+        )
+        st.session_state[model_key]["private_key"] = st.text_area(
+            "Private Key",
+            value=st.session_state[model_key]
+            .get("private_key", "")
+            .replace("\\n", "\n"),
+            height=150,
+            help="Paste private key here. Newlines will be preserved.",
+        )
+
+        # Update how default_folder_id and deepdoc_action_label are retrieved and set
+        default_folder_id_val = st.session_state[model_key].get("default_folder_id", "")
+        st.session_state[model_key]["default_folder_id"] = st.text_input(
+            "Default Google Drive Folder ID (Optional)",
+            value=default_folder_id_val,
+            key=f"{model_key}_default_folder_id_input",
+        )
+
+        deepdoc_label_val = st.session_state[model_key].get(
+            "deepdoc_action_label", "DeepDocClientAction"
+        )
+        st.session_state[model_key]["deepdoc_action_label"] = st.text_input(
+            "DeepDoc Client Action Label",
+            value=deepdoc_label_val,
+            key=f"{model_key}_deepdoc_label_input",
+        )
+
+        # New Config items for watcher
+        st.markdown("---")
+        st.markdown(
+            "**Watcher Configuration (Restart agent after changing webhook base URL here)**"
+        )
+        st.session_state[model_key]["default_webhook_base_url"] = st.text_input(
+            "Default Jiva Webhook Base URL (e.g., https://your-jiva.com)",
+            value=st.session_state[model_key].get("default_webhook_base_url", ""),
+            help="Your publicly accessible Jiva instance URL. Needed for Google to send notifications.",
+        )
+        st.session_state[model_key]["pulse_interval_seconds"] = st.number_input(
+            "Pulse Interval for Renewals (seconds)",
+            min_value=60,
+            value=st.session_state[model_key].get("pulse_interval_seconds", 3600),
+        )
+        st.session_state[model_key]["renew_threshold_hours"] = st.number_input(
+            "Renew Watch Threshold (hours before expiry)",
+            min_value=1,
+            value=st.session_state[model_key].get("renew_threshold_hours", 6),
+        )
+        # For 'watched_gdrive_resources', direct YAML editing in DAF is better.
+        # UI could show current configured list if read-only from DAF.
+        current_watched_resources = st.session_state[model_key].get(
+            "watched_gdrive_resources", []
+        )
+        st.write("Watched GDrive Resources (configured in DAF):")
+        if current_watched_resources:
+            st.json(current_watched_resources)
+        else:
+            st.caption("No GDrive resources configured for automatic watching in DAF.")
+
+        app_update_action(agent_id, action_id)  # Save config changes
+
+    st.subheader("Ingest Documents from Google Drive")
+    with st.form("ingest_form"):
+        ingest_type = st.radio(
+            "Ingest Type:",
+            ("Folder", "Specific Files"),
+            horizontal=True,
+            key=f"{model_key}_ingest_type",
+        )
+        drive_ids_input_key = f"{model_key}_drive_ids_input"
+        st.text_area(
+            f"Google Drive {'Folder ID(s)' if ingest_type == 'Folder' else 'File ID(s)'} (comma-separated)",
+            height=80,
+            key=drive_ids_input_key,
+        )
+        user_metadata_input_key = f"{model_key}_user_metadata_input"
+        st.text_area(
+            "Optional User Metadata (JSON string for all items in this batch)",
+            value="{}",
+            height=80,
+            help='Example: {"project": "Alpha", "status": "draft"}',
+            key=user_metadata_input_key,
+        )
+        submitted_ingest = st.form_submit_button("Start Ingestion")
+
+    if submitted_ingest and st.session_state[drive_ids_input_key]:
+        ids_list = [
+            id.strip()
+            for id in st.session_state[drive_ids_input_key].split(",")
+            if id.strip()
+        ]
+        item_type_arg = "folder" if ingest_type == "Folder" else "file"
+        parsed_user_metadata = None
+        try:
+            parsed_user_metadata = (
+                json.loads(st.session_state[user_metadata_input_key])
+                if st.session_state[user_metadata_input_key]
+                else {}
+            )
+        except json.JSONDecodeError:
+            st.error("Invalid JSON format for User Metadata.")
+            parsed_user_metadata = None  # Ensure it's None if parsing fails
+
+        if ids_list and (
+            parsed_user_metadata is not None
+        ):  # Check if parsed_user_metadata is not None
+            with st.spinner(f"Ingesting {ingest_type}(s): {', '.join(ids_list)}..."):
+                payload = {
+                    "drive_ids": ids_list,
+                    "item_type": item_type_arg,
+                    "user_metadata": parsed_user_metadata,
+                }
+                result_data = call_action_walker_exec(
+                    agent_id=agent_id,  # Changed from agent_jid
+                    module_root=module_root,
+                    walker="ingest_gdrive_items_walker",  # Changed from walker_name
+                    args=payload,  # Changed from payload
+                    # sync=True # jvcli call_action_walker_exec defaults to sync=True
+                )
+                result = (
+                    result_data if result_data and isinstance(result_data, dict) else {}
+                )
+
+                if result:
+                    st.write("Ingestion Results:")
+                    if result.get("succeeded"):
+                        st.success(
+                            f"Successfully initiated ingestion for: {result['succeeded']}"
+                        )
+                    if result.get("failed"):
+                        st.error(
+                            f"Failed to initiate ingestion for: {result['failed']}"
+                        )
+                    if result.get("job_ids"):
+                        st.info(f"DeepDoc Job ID(s) created: {result['job_ids']}")
+
+                    # Rerun with reloaded UI
+                    del st.session_state[f"{model_key}_all_ingested_docs"]
+                    st.session_state[f"{model_key}_active_watches_cache"] = (
+                        None  # Invalidate cache
+                    )
+                    st.rerun()  # Rerun to fetch fresh list
+                else:
+                    st.error(
+                        f"Failed to trigger ingestion walker or walker returned no/unexpected response. Full walker response: {result_data}"
+                    )
+        elif not ids_list:
+            st.warning("Please enter at least one Drive ID.")
+        # Added else for when parsed_user_metadata is None due to JSON error
+        elif parsed_user_metadata is None:
+            st.warning("Ingestion aborted due to invalid User Metadata JSON.")
+
+    st.markdown("---")
+    st.subheader("Manage Google Drive Watchers")
+
+    col_watch1, col_watch2 = st.columns(2)
+    with col_watch1:
+        with st.form("start_watch_form"):
+            st.markdown("**Start Watching a Resource**")
+            st.session_state.gdrive_watch_resource_id = st.text_input(
+                "Google Drive File/Folder ID to Watch",
+                value=st.session_state.gdrive_watch_resource_id,
+            )
+            # Add a resource type radio selection
+            resource_type_options = ["file", "folder"]
+            resource_type_index = (
+                resource_type_options.index(st.session_state.gdrive_watch_resource_type)
+                if st.session_state.gdrive_watch_resource_type in resource_type_options
+                else 0
+            )
+            st.session_state.gdrive_watch_resource_type = st.radio(
+                "Resource Type:",
+                options=resource_type_options,
+                index=resource_type_index,
+                horizontal=True,
+                help="Specify whether this is a file or folder resource",
+            )
+
+            webhook_base_for_start = st.text_input(
+                "Jiva Webhook Base URL (if different from default)",
+                value=st.session_state[model_key].get("default_webhook_base_url", ""),
+                help="Overrides default if set. Ensure it's publicly accessible.",
+            )
+            submitted_start_watch = st.form_submit_button("Start Watch")
+
+        if submitted_start_watch and st.session_state.gdrive_watch_resource_id:
+            with st.spinner(
+                f"Attempting to start watch on {st.session_state.gdrive_watch_resource_id}..."
+            ):
+                payload = {
+                    "operation": "start",
+                    "gdrive_resource_id": st.session_state.gdrive_watch_resource_id,
+                    "resource_type": st.session_state.gdrive_watch_resource_type,  # Add the resource type to the payload
+                    "webhook_base_url": webhook_base_for_start
+                    or st.session_state[model_key].get("default_webhook_base_url"),
+                }
+                if not payload["webhook_base_url"]:
+                    st.error(
+                        "Webhook Base URL is required to start a watch. Configure it in the section above or provide here."
+                    )
+                else:
+                    result_data = call_action_walker_exec(
+                        agent_id, module_root, "manage_gdrive_watch_walker", payload
+                    )
+                    result = (
+                        result_data
+                        if result_data and isinstance(result_data, dict)
+                        else {}
+                    )
+                    if result.get("status") == "succeeded":
+                        st.success(
+                            f"Watch started successfully! Jiva UUID: {result.get('jiva_channel_uuid')}"
+                        )
+                        st.json(result.get("details", {}))
+                        st.session_state[f"{model_key}_active_watches_cache"] = (
+                            None  # Invalidate cache
+                        )
+                    else:
+                        st.error(
+                            f"Failed to start watch: {result.get('message', 'Unknown error')}"
+                        )
+                        if result.get("details"):
+                            st.json(
+                                result.get("details")
+                            )  # Show Google's error if present
+
+    with col_watch2:
+        with st.form("stop_watch_form"):
+            st.markdown("**Stop Watching a Resource**")
+            st.session_state.gdrive_jiva_channel_uuid_to_stop = st.text_input(
+                "Jiva Watch Channel UUID to Stop",
+                value=st.session_state.gdrive_jiva_channel_uuid_to_stop,
+                help="This is the UUID generated by Jiva when the watch was started.",
+            )
+            submitted_stop_watch = st.form_submit_button("Stop Watch")
+
+        if submitted_stop_watch and st.session_state.gdrive_jiva_channel_uuid_to_stop:
+            with st.spinner(
+                f"Attempting to stop watch {st.session_state.gdrive_jiva_channel_uuid_to_stop}..."
+            ):
+                payload = {
+                    "operation": "stop",
+                    "jiva_channel_uuid": st.session_state.gdrive_jiva_channel_uuid_to_stop,
+                }
+                result_data = call_action_walker_exec(
+                    agent_id, module_root, "manage_gdrive_watch_walker", payload
+                )
+                result = (
+                    result_data if result_data and isinstance(result_data, dict) else {}
+                )
+                if result.get("status") == "succeeded":
+                    st.success(result.get("message", "Watch stopped successfully."))
+                    st.session_state[f"{model_key}_active_watches_cache"] = (
+                        None  # Invalidate cache
+                    )
+                else:
+                    st.error(
+                        f"Failed to stop watch: {result.get('message', 'Unknown error')}"
+                    )
+
+    st.markdown("---")
+    st.markdown("**Active Google Drive Watchers**")
+    if st.button("🔄 Refresh Active Watchers List", key=f"{model_key}_refresh_watches"):
+        st.session_state[f"{model_key}_active_watches_cache"] = None  # Invalidate cache
+        st.rerun()  # Rerun to fetch fresh list
+
+    # Use cached list if available
+    if st.session_state.get(f"{model_key}_active_watches_cache") is None:
+        with st.spinner("Fetching active watchers list..."):
+            list_payload = {"operation": "list"}
+            list_result_data = call_action_walker_exec(
+                agent_id, module_root, "manage_gdrive_watch_walker", list_payload
+            )
+            list_result = (
+                list_result_data
+                if list_result_data and isinstance(list_result_data, dict)
+                else {}
+            )
+            st.session_state[f"{model_key}_active_watches_cache"] = list_result.get(
+                "active_watches", []
+            )
+
+    active_watches = st.session_state[f"{model_key}_active_watches_cache"]
+
+    if active_watches:
+        st.write(f"Found {len(active_watches)} active Jiva-managed watch channels:")
+        for watch in active_watches:
+            col_disp1, col_disp2, col_disp3 = st.columns([3, 2, 1])
+            with col_disp1:
+                st.markdown(f"**GDrive ID:** `{watch.get('gdrive_resource_id')}`")
+                st.caption(f"Jiva UUID: `{watch.get('jiva_channel_uuid')}`")
+            with col_disp2:
+                st.caption(f"Google CH ID: `{watch.get('google_channel_id')}`")
+                st.caption(f"Expires: {watch.get('expires_at_iso')}")
+            with col_disp3:
+                if st.button(
+                    "Force Renew",
+                    key=f"renew_{watch.get('jiva_channel_uuid')}",
+                    help="Manually trigger renewal for this watch.",
+                ):
+                    with st.spinner(
+                        f"Renewing watch {watch.get('jiva_channel_uuid')}..."
+                    ):
+                        renew_payload = {
+                            "operation": "renew",
+                            "jiva_channel_uuid": watch.get("jiva_channel_uuid"),
+                        }
+                        renew_res_data = call_action_walker_exec(
+                            agent_id,
+                            module_root,
+                            "manage_gdrive_watch_walker",
+                            renew_payload,
+                        )
+                        renew_res = (
+                            renew_res_data
+                            if renew_res_data and isinstance(renew_res_data, dict)
+                            else {}
+                        )
+                        if renew_res.get("status") == "succeeded":
+                            st.success(
+                                f"Renewal initiated for {watch.get('jiva_channel_uuid')}. New Jiva UUID: {renew_res.get('jiva_channel_uuid')}"
+                            )
+                        else:
+                            st.error(f"Renewal failed: {renew_res.get('message')}")
+                        st.session_state[f"{model_key}_active_watches_cache"] = (
+                            None  # Invalidate cache
+                        )
+                        st.rerun()
+
+            st.divider()
+    elif (
+        isinstance(active_watches, list) and not active_watches
+    ):  # Empty list explicitly
+        st.info("No active Google Drive watchers managed by Jiva currently.")
+    else:  # Error or unexpected response from walker
+        st.error("Could not retrieve active watchers list or an error occurred.")
+        if active_watches:
+            st.json(active_watches)  # Show raw response if it's not the expected list
+
+    if st.button(
+        "Attempt to Recover All Configured Watches",
+        key=f"{model_key}_recover_watches_btn",
+    ):
+        with st.spinner("Attempting to recover watches based on DAF configuration..."):
+            webhook_base_for_recovery = st.session_state[model_key].get(
+                "default_webhook_base_url"
+            )
+            if not webhook_base_for_recovery:
+                st.error(
+                    "Default Webhook Base URL must be configured in the 'Configuration' section above to attempt recovery."
+                )
+            else:
+                recover_payload = {
+                    "operation": "recover",
+                    "webhook_base_url": webhook_base_for_recovery,
+                }
+                recover_result_data = call_action_walker_exec(
+                    agent_id, module_root, "manage_gdrive_watch_walker", recover_payload
+                )
+                recover_result = (
+                    recover_result_data
+                    if recover_result_data and isinstance(recover_result_data, dict)
+                    else {}
+                )
+                st.write("Recovery Attempt Results:")
+                st.json(recover_result)
+                st.session_state[f"{model_key}_active_watches_cache"] = (
+                    None  # Invalidate cache
+                )
+                st.rerun()
+
+    # --- Management Section ---
+    st.subheader("Manage Ingested Drive Documents")
+
+    # Fetch all documents once
+    if f"{model_key}_all_ingested_docs" not in st.session_state:
+        with st.spinner("Loading all ingested Google Drive documents..."):
+            result_data = call_action_walker_exec(
+                agent_id=agent_id,  # Changed from agent_jid
+                module_root=module_root,
+                walker="get_ingested_gdrive_docs_walker",  # Changed from walker_name
+                args={},  # Changed from payload
+            )
+            # Store the full list in session state
+            st.session_state[f"{model_key}_all_ingested_docs"] = (
+                result_data if result_data and isinstance(result_data, list) else []
+            )
+            # Reset current page if data is reloaded
+            st.session_state[f"{model_key}_current_page_ingested"] = 1
+
+    all_ingested_docs = st.session_state.get(f"{model_key}_all_ingested_docs", [])
+
+    if all_ingested_docs and not (
+        isinstance(all_ingested_docs, list)
+        and len(all_ingested_docs) > 0
+        and "error" in all_ingested_docs[0]
+    ):
+        # --- Pagination Controls ---
+        items_per_page_key = f"{model_key}_items_per_page_ingested"
+        current_page_key = f"{model_key}_current_page_ingested"
+
+        items_per_page = st.selectbox(
+            "Items per page:",
+            options=[5, 10, 20, 50, 100],
+            index=[5, 10, 20, 50, 100].index(
+                st.session_state.get(items_per_page_key, 10)
+            ),
+            key=f"{items_per_page_key}_selector",  # Unique key for the selectbox
+        )
+        # Update session state if selectbox changes
+        if st.session_state.get(items_per_page_key) != items_per_page:
+            st.session_state[items_per_page_key] = items_per_page
+            st.session_state[current_page_key] = (
+                1  # Reset to first page on items_per_page change
+            )
+            st.rerun()  # Rerun to apply new items_per_page
+
+        total_items = len(all_ingested_docs)
+        total_pages = (
+            math.ceil(total_items / items_per_page) if items_per_page > 0 else 1
+        )
+
+        # Ensure current_page is within valid bounds
+        st.session_state[current_page_key] = max(
+            1, min(st.session_state.get(current_page_key, 1), total_pages)
+        )
+
+        # Calculate slice for current page
+        start_idx = (st.session_state[current_page_key] - 1) * items_per_page
+        end_idx = start_idx + items_per_page
+        paginated_docs = all_ingested_docs[start_idx:end_idx]
+
+        st.write(
+            f"Showing {len(paginated_docs)} of {total_items} Google Drive items in DeepDoc manifest (Page {st.session_state[current_page_key]}/{total_pages})"
+        )
+
+        # Navigation buttons
+        col_nav1, col_nav2, col_nav3, col_nav4 = st.columns(
+            [1, 1, 5, 1]
+        )  # Adjusted layout
+        with col_nav1:
+            if st.button(
+                "⬅️ Prev",
+                key=f"{model_key}_prev_page",
+                disabled=(st.session_state[current_page_key] <= 1),
+            ):
+                st.session_state[current_page_key] -= 1
+                st.rerun()
+        with col_nav2:
+            if st.button(
+                "Next ➡️",
+                key=f"{model_key}_next_page",
+                disabled=(st.session_state[current_page_key] >= total_pages),
+            ):
+                st.session_state[current_page_key] += 1
+                st.rerun()
+        # col_nav3 for spacing
+        with col_nav4:
+            if st.button("🔄 Refresh List", key=f"{model_key}_refresh_docs"):
+                # Clear the cached list to force a reload
+                if f"{model_key}_all_ingested_docs" in st.session_state:
+                    del st.session_state[f"{model_key}_all_ingested_docs"]
+                st.rerun()
+
+        # --- Display Paginated Documents ---
+        for doc_idx, doc in enumerate(paginated_docs):
+            # Unique key for elements within the loop, incorporating page and item index
+            # This is crucial if the content of `doc` can change between pages but idx might repeat
+            # A more robust key would be based on a unique ID from the doc itself (e.g., gdrive_file_id)
+            item_unique_id = doc.get("metadata", {}).get(
+                "google_drive_file_id", f"item_{start_idx + doc_idx}"
+            )
+
+            gdrive_file_id = doc.get("metadata", {}).get("google_drive_file_id", "N/A")
+            gdrive_filename = doc.get("metadata", {}).get(
+                "google_drive_filename", doc.get("filename", "N/A")
+            )
+            deepdoc_job_id = doc.get("job_id", "N/A")
+
+            col1, col2, col3 = st.columns([3, 2, 1])
+            with col1:
+                st.markdown(f"**{gdrive_filename}** (GDrive ID: `{gdrive_file_id}`)")
+                st.caption(
+                    f"DeepDoc Job: `{deepdoc_job_id}`, Orig. Filename: `{doc.get('filename')}`"
+                )
+            with col2:
+                if st.button("Re-ingest (Update)", key=f"update_{item_unique_id}"):
+                    with st.spinner(
+                        f"Requesting re-ingestion for {gdrive_filename}..."
+                    ):
+                        del_payload = {"google_drive_file_id": gdrive_file_id}
+                        del_result_data = call_action_walker_exec(
+                            agent_id,
+                            module_root,
+                            "remove_gdrive_item_walker",
+                            del_payload,
+                        )
+                        del_res = (
+                            del_result_data
+                            if del_result_data and isinstance(del_result_data, dict)
+                            else {}
+                        )
+
+                        if del_res and del_res.get("status") == "succeeded":
+                            st.info(
+                                f"Old version of {gdrive_filename} removed. Starting re-ingestion..."
+                            )
+                            # Pass original metadata for consistency during re-ingestion
+                            original_metadata = doc.get("metadata", {})
+                            # Remove GDrive specific fields if they are re-added by ingest_drive_items to avoid deep nesting
+                            original_metadata.pop("google_drive_file_id", None)
+                            original_metadata.pop("google_drive_filename", None)
+                            original_metadata.pop("google_drive_mimetype", None)
+                            original_metadata.pop("google_drive_folder_id", None)
+                            original_metadata.pop("source_system", None)
+
+                            ingest_payload = {
+                                "drive_ids": [gdrive_file_id],
+                                "item_type": "file",
+                                "user_metadata": original_metadata,
+                            }
+                            ingest_result_data = call_action_walker_exec(
+                                agent_id,
+                                module_root,
+                                "ingest_gdrive_items_walker",
+                                ingest_payload,
+                            )
+                            ingest_res = (
+                                ingest_result_data
+                                if ingest_result_data
+                                and isinstance(ingest_result_data, dict)
+                                else {}
+                            )
+
+                            if ingest_res and ingest_res.get("succeeded"):
+                                st.success(
+                                    f"Re-ingestion started for {gdrive_filename}."
+                                )
+                            else:
+                                st.error(
+                                    f"Failed to start re-ingestion for {gdrive_filename}: {ingest_res}"
+                                )
+                        else:
+                            st.error(
+                                f"Failed to remove old version of {gdrive_filename} for update: {del_res}"
+                            )
+                        # Clear cache and rerun to see changes
+                        if f"{model_key}_all_ingested_docs" in st.session_state:
+                            del st.session_state[f"{model_key}_all_ingested_docs"]
+                        st.rerun()
+            with col3:
+                if st.button("Remove from Store", key=f"delete_{item_unique_id}"):
+                    with st.spinner(f"Removing {gdrive_filename} from vector store..."):
+                        payload = {"google_drive_file_id": gdrive_file_id}
+                        delete_result_data = call_action_walker_exec(
+                            agent_id=agent_id,
+                            module_root=module_root,
+                            walker="remove_gdrive_item_walker",
+                            args=payload,
+                        )
+                        delete_result = (
+                            delete_result_data
+                            if delete_result_data
+                            and isinstance(delete_result_data, dict)
+                            else {}
+                        )
+
+                        if delete_result and delete_result.get("status") == "succeeded":
+                            st.success(delete_result.get("message"))
+                        else:
+                            st.error(
+                                delete_result.get("message", "Failed to remove item.")
+                            )
+                        # Clear cache and rerun
+                        if f"{model_key}_all_ingested_docs" in st.session_state:
+                            del st.session_state[f"{model_key}_all_ingested_docs"]
+
+                        st.session_state[f"{model_key}_active_watches_cache"] = (
+                            None  # Invalidate cache
+                        )
+                        st.rerun()
+            st.divider()
+
+    elif (
+        all_ingested_docs
+        and isinstance(all_ingested_docs, list)
+        and len(all_ingested_docs) > 0
+        and "error" in all_ingested_docs[0]
+    ):
+        st.error(
+            f"Error fetching ingested documents: {all_ingested_docs[0].get('error', 'Unknown error')}"
+        )
+    else:  # Handles empty list or other non-error but non-list cases
+        st.info("No Google Drive documents found in DeepDoc manifest.")
+
+    # --- Remove Entire Folder Section (remains largely the same) ---
+    st.markdown("---")
+    st.write("Remove All Items from a Google Drive Folder (from Vector Store Only)")
+    gdrive_folder_to_clear_input_key = f"{model_key}_gdrive_folder_to_clear_input"
+    st.text_input(
+        "Google Drive Folder ID to Clear", key=gdrive_folder_to_clear_input_key
+    )
+    if st.button("Clear Folder from Vector Store"):
+        if st.session_state[gdrive_folder_to_clear_input_key]:
+            with st.spinner(
+                f"Removing all items from folder {st.session_state[gdrive_folder_to_clear_input_key]} from vector store..."
+            ):
+                payload = {
+                    "google_drive_folder_id": st.session_state[
+                        gdrive_folder_to_clear_input_key
+                    ]
+                }
+                clear_result_data = call_action_walker_exec(
+                    agent_id=agent_id,
+                    module_root=module_root,
+                    walker="clear_gdrive_folder_walker",
+                    args=payload,
+                )
+                clear_result = (
+                    clear_result_data
+                    if clear_result_data and isinstance(clear_result_data, dict)
+                    else {}
+                )
+
+                if clear_result:
+                    st.info(clear_result.get("message", "Clear operation finished."))
+                    if clear_result.get("deleted_files"):
+                        st.write(
+                            f"Removed: {len(clear_result['deleted_files'])} files."
+                        )
+                    if clear_result.get("failed_files"):
+                        st.warning(
+                            f"Failed to remove: {len(clear_result['failed_files'])} files."
+                        )
+                else:
+                    st.error("Failed to trigger folder clearing operation.")
+                # Clear cache and rerun
+                if f"{model_key}_all_ingested_docs" in st.session_state:
+                    del st.session_state[f"{model_key}_all_ingested_docs"]
+
+                st.session_state[f"{model_key}_active_watches_cache"] = (
+                    None  # Invalidate cache
+                )
+                st.rerun()
+        else:
+            st.warning("Please enter a Google Drive Folder ID to clear.")

--- a/deepdoc_google_drive_action/clear_gdrive_folder_walker.jac
+++ b/deepdoc_google_drive_action/clear_gdrive_folder_walker.jac
@@ -1,0 +1,26 @@
+# --- Walkers for DeepDocGoogleDriveAction UI interaction ---
+
+import:py from typing { List, Dict, Optional }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+
+# Walker to remove all items from a Drive folder from the vector store
+walker clear_gdrive_folder_walker :interact_graph_walker: {
+    has google_drive_folder_id: str = "";
+    has response: Dict = {};
+
+    can on_agent with Agent entry {
+        visit [-->](`?Actions);
+    }
+    can on_actions with Actions entry {
+        visit [-->](`?Action)(?enabled==True)(?label=='DeepDocGoogleDriveAction');
+    }
+    can on_google_drive_action with Action entry {
+        self.response = here.remove_drive_folder_from_vector_store(
+            google_drive_folder_id=self.google_drive_folder_id
+        );
+    }
+}

--- a/deepdoc_google_drive_action/deepdoc_google_drive_action.jac
+++ b/deepdoc_google_drive_action/deepdoc_google_drive_action.jac
@@ -1,0 +1,862 @@
+import:py logging;
+import:py traceback;
+import:py os;
+import:py json; # For metadata string conversion if needed
+import:py uuid; # For generating Jiva channel UUIDs
+import:py time; # For expiration calculations
+import:py from logging { Logger }
+import:py from datetime { datetime, timedelta, timezone } # For expiration calculations
+import:py from typing { Union, List, Dict, Optional }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:py from .modules.google_drive_handler { GoogleDriveHandler }
+import:py from jivas.agent.modules.agentlib.utils { Utils }
+import:py from jvserve.lib.agent_interface { AgentInterface } # For webhook key generation
+
+
+node DeepDocGoogleDriveAction :Action: {
+    has description:str = "Integrates with Google Drive to ingest documents into DeepDoc.";
+    has scopes:list = ["https://www.googleapis.com/auth/drive.readonly"]; # Start with readonly, expand if needed
+    has default_folder_id:str = ""; # Can be overridden by agent config
+
+    # Service account credentials (to be set in DAF)
+    has info_type:str = "";
+    has project_id:str = "";
+    has private_key_id:str = "";
+    has private_key:str = ""; # Multiline string in YAML
+    has client_email:str = "";
+    has client_id:str = "";
+    has auth_uri:str = "";
+    has token_uri:str = "";
+    has auth_provider_x509_cert_url:str = "https://www.googleapis.com/oauth2/v1/certs";
+    has client_x509_cert_url:str = "";
+    has universe_domain:str = "googleapis.com";
+
+    has active_watch_channels: dict = {}; # {jiva_channel_uuid: {g_channel_id, g_resource_id, gdrive_id, expiration_ms, token}}
+
+    has pulse_interval_seconds: int = 3600; # e.g., check every hour
+    has renew_threshold_hours: int = 6; # Renew if expiration is within this many hours
+
+    # To be configured in DAF: List of {'gdrive_id': '...', 'type': 'file'/'folder'}
+    has watched_gdrive_resources: list[dict] = [];
+    has default_webhook_base_url: str = ""; # e.g., "https://your-jiva-instance.com" - SET IN DAF
+
+    has auto_watch_on_ingest: bool = True; # Default to True, can be overridden in DAF
+    has page_token: str = "";
+
+    has deepdoc_action_label: str = "DeepDocClientAction"; # Label of the DeepDoc action
+
+    # --- Internal State (Logger only) ---
+    static has logger:Logger = logging.getLogger(__name__);
+
+    can on_register() {
+        if self.enabled {
+            self.on_enable();
+        }
+    }
+
+    can on_enable() { # Called when agent becomes active or action is enabled
+        self.logger.info("DeepDocGoogleDriveAction enabled. Initializing...");
+
+        if(not self.page_token) {
+            drive_handler = self.get_drive_handler();
+            if (not drive_handler) { self.logger.error("GDrive Handler not available."); }
+
+            self.page_token = drive_handler.get_initial_start_page_token();
+        }
+
+        if (not self.default_webhook_base_url) {
+            self.default_webhook_base_url = os.environ.get('JIVAS_BASE_URL');
+        }
+
+        webhook_base = self.default_webhook_base_url;
+        if (not webhook_base) {
+             self.logger.error("JIVAS_BASE_URL environment variable or default_webhook_base_url DAF config not set. Watch recovery and new watches may fail.");
+        } else {
+            # Store for later use if it came from ENV
+            if (not self.default_webhook_base_url) { self.default_webhook_base_url = webhook_base; }
+            self.recover_watches(webhook_base_url=webhook_base);
+        }
+        self.start_pulse_scheduler();
+    }
+
+    can on_disable() {
+        self.logger.info("DeepDocGoogleDriveAction disabling. Stopping pulse and watches.");
+        self.stop_pulse_scheduler();
+        jiva_uuids_to_stop = list(self.active_watch_channels.keys());
+        for jiva_uuid in jiva_uuids_to_stop {
+            self.stop_watching_resource(jiva_channel_uuid=jiva_uuid, initiated_by_user=False);
+        }
+        self.active_watch_channels = {};
+    }
+
+    can get_drive_handler() -> Optional[GoogleDriveHandler] {
+        credentials_info = {
+            "type": self.info_type, "project_id": self.project_id,
+            "private_key_id": self.private_key_id, "private_key": self.private_key.replace('\\n', '\n'),
+            "client_email": self.client_email, "client_id": self.client_id,
+            "auth_uri": self.auth_uri, "token_uri": self.token_uri,
+            "auth_provider_x509_cert_url": self.auth_provider_x509_cert_url,
+            "client_x509_cert_url": self.client_x509_cert_url, "universe_domain": self.universe_domain
+        };
+        if (not self.project_id or not self.private_key or not self.client_email) {
+            self.logger.error("GDrive credentials not fully configured."); return None;
+        }
+        try {
+            handler = GoogleDriveHandler(credentials_info=credentials_info, scopes=self.scopes);
+            return handler if handler.is_healthy() else None;
+        } except Exception as e {
+            self.logger.error(f"Exception creating GDriveHandler: {e}"); return None;
+        }
+    }
+
+    can get_deepdoc_action() {
+        dd_action = self.get_agent().get_actions().get(action_label=self.deepdoc_action_label);
+        if (not dd_action) {
+            self.logger.error(f"DeepDocClientAction '{self.deepdoc_action_label}' not found.");
+            return None;
+        }
+        return dd_action;
+    }
+
+    can start_watching_resource(gdrive_resource_id: str, resource_type: str, webhook_base_url: Optional[str] = None) -> Dict {
+        # resource_type: 'file' or 'folder' (this is for our tracking, Google API always uses fileId)
+        effective_webhook_base_url = webhook_base_url if webhook_base_url else self.default_webhook_base_url;
+        if (not effective_webhook_base_url) {
+             effective_webhook_base_url = os.environ.get('JIVAS_BASE_URL');
+             if (not effective_webhook_base_url) {
+                 self.logger.error("Webhook base URL not configured. Cannot start watch.");
+                 return {"status": "failed", "message": "Webhook base URL not configured."};
+             }
+             if (not self.default_webhook_base_url) { self.default_webhook_base_url = effective_webhook_base_url; }
+        }
+
+        drive_handler = self.get_drive_handler();
+        if (not drive_handler) { return {"status": "failed", "message": "GDrive Handler not available."}; }
+
+        # Check if this exact gdrive_resource_id is already being watched
+        for (j_uuid, watch_info) in self.active_watch_channels.items() {
+            if (watch_info.get("gdrive_id_watched") == gdrive_resource_id) {
+                self.logger.info(f"GDrive resource {gdrive_resource_id} already actively watched by Jiva UUID {j_uuid}. Checking expiration.");
+                # If it's nearing expiration, renew it, otherwise confirm it's active
+                if (watch_info.get("expiration_ms", 0) < (int(datetime.now(timezone.utc).timestamp() * 1000) + (self.renew_threshold_hours * 3600 * 1000))) {
+                    return self.renew_watch_channel(jiva_channel_uuid=j_uuid);
+                } else {
+                    return {"status": "already_active", "jiva_channel_uuid": j_uuid, "details": watch_info};
+                }
+            }
+        }
+
+        jiva_channel_uuid = str(uuid.uuid4());
+        webhook_token = f"jiva_watch_token_{jiva_channel_uuid}"; # To validate incoming notifications
+        agent_id = self.get_agent().id;
+
+        if (effective_webhook_base_url.endswith('/')) { effective_webhook_base_url = effective_webhook_base_url[:-1]; }
+
+        webhook_key = AgentInterface.encrypt_webhook_key(
+            agent_id=agent_id, module_root=self.get_module_root(), walker="gdrive_notification_receiver_walker"
+        );
+        full_webhook_url = f"{effective_webhook_base_url}/webhook/{webhook_key}";
+
+        expiration_dt = datetime.now(timezone.utc) + timedelta(days=1); # Google's default max is often 1 day
+        expiration_ms = int(expiration_dt.timestamp() * 1000);
+
+        self.logger.info(f"Starting watch for GDrive ID: {gdrive_resource_id} (Type: {resource_type}), Jiva UUID: {jiva_channel_uuid}, Callback: {full_webhook_url}");
+
+        watch_response = drive_handler.watch_file(
+            file_id=gdrive_resource_id, channel_id=jiva_channel_uuid,
+            channel_token=webhook_token, webhook_url=full_webhook_url, expiration_ms=expiration_ms
+        );
+
+        if (watch_response and "id" in watch_response and "resourceId" in watch_response) {
+            self.active_watch_channels[jiva_channel_uuid] = {
+                "jiva_channel_uuid": jiva_channel_uuid,
+                "google_channel_id": watch_response["id"], # Google's ID for this channel instance
+                "google_resource_id": watch_response["resourceId"], # Google's opaque ID for the watched GDrive resource
+                "gdrive_id_watched": gdrive_resource_id, # The actual GDrive ID we are watching
+                "type": resource_type, # 'file' or 'folder' - our classification
+                "expiration_ms": int(watch_response.get("expiration", expiration_ms)),
+                "webhook_token": webhook_token,
+                "webhook_url": full_webhook_url,
+                "created_at_iso": datetime.now(timezone.utc).isoformat()
+            };
+            self.logger.info(f"Watch started: Jiva UUID {jiva_channel_uuid}, GDrive ID {gdrive_resource_id}, Google CH ID {watch_response['id']}.");
+            return {"status": "succeeded", "jiva_channel_uuid": jiva_channel_uuid, "details": self.active_watch_channels[jiva_channel_uuid]};
+        } else {
+            error_detail = watch_response.get("error", "Unknown GDrive API error during watch.");
+            if (isinstance(watch_response, dict) and "reason" in watch_response){
+                error_detail = f"{error_detail} (Reason: {watch_response.get('reason')}, Status: {watch_response.get('details')})";
+            }
+
+            self.logger.error(f"Failed to start watch for GDrive ID {gdrive_resource_id}: {error_detail}");
+            return {"status": "failed", "message": f"Google API error: {error_detail}"};
+        }
+    }
+
+    can stop_watching_resource(jiva_channel_uuid: str, initiated_by_user: bool = False) -> Dict {
+        drive_handler = self.get_drive_handler();
+        if (not drive_handler) {
+            return {"status": "failed", "message": "Google Drive Handler not available."};
+        }
+
+        watch_info = self.active_watch_channels.get(jiva_channel_uuid);
+        if (not watch_info) {
+            self.logger.warning(f"Attempted to stop non-existent Jiva watch UUID: {jiva_channel_uuid}");
+            return {"status": "not_found", "message": f"Jiva watch UUID {jiva_channel_uuid} not found."};
+        }
+
+        google_channel_id = watch_info["google_channel_id"];
+        google_resource_id = watch_info["google_resource_id"];
+
+        self.logger.info(f"Stopping watch: Jiva UUID {jiva_channel_uuid}, Google CH ID {google_channel_id}");
+
+        stop_response = drive_handler.stop_channel(
+            channel_id=google_channel_id, resource_id=google_resource_id
+        );
+
+        remove_from_active = False;
+        if (initiated_by_user) { remove_from_active = True; }
+        elif (stop_response and stop_response.get("status") == "success") { remove_from_active = True; }
+        elif (stop_response and "error" in stop_response and stop_response.get("details") == 404) {
+             self.logger.warning(f"Google channel {google_channel_id} (404) during stop. Removing from Jiva active list.");
+             remove_from_active = True;
+        }
+
+        if (remove_from_active and jiva_channel_uuid in self.active_watch_channels) {
+            del self.active_watch_channels[jiva_channel_uuid];
+            self.logger.info(f"Removed Jiva watch UUID {jiva_channel_uuid} from active list.");
+        }
+
+        if (stop_response and stop_response.get("status") == "success") {
+            return {"status": "succeeded", "message": f"Stopped watch for Jiva UUID {jiva_channel_uuid}."};
+        } else {
+            error_detail = stop_response.get("error", "Unknown error stopping channel.");
+            return {"status": "failed", "message": f"Failed to stop watch {jiva_channel_uuid}: {error_detail}"};
+        }
+    }
+
+    can renew_watch_channel(jiva_channel_uuid: str) -> Dict {
+        watch_info = self.active_watch_channels.get(jiva_channel_uuid);
+        if (not watch_info) {
+            self.logger.warning(f"Cannot renew non-existent Jiva watch UUID: {jiva_channel_uuid}");
+            return {"status": "not_found", "message": "Watch not found."};
+        }
+        gdrive_resource_id_to_watch = watch_info["gdrive_id_watched"];
+        resource_type_to_watch = watch_info["type"]; # 'file' or 'folder'
+
+        self.logger.info(f"Renewing watch for Jiva UUID {jiva_channel_uuid}, GDrive ID {gdrive_resource_id_to_watch}.");
+
+        stop_result = self.stop_watching_resource(jiva_channel_uuid=jiva_channel_uuid, initiated_by_user=False);
+        # We proceed even if stop fails slightly (e.g. 404), as the old channel might be dead anyway.
+        # Critical failure in stop might be logged by stop_watching_resource.
+        if (stop_result.get("status") == "failed" and stop_result.get("message") != f"Jiva watch channel UUID {jiva_channel_uuid} not found.") {
+            self.logger.warning(f"Attempted to stop old channel {jiva_channel_uuid} during renewal, but it might have failed or was already gone: {stop_result.get('message')}. Proceeding with new watch attempt.");
+        }
+
+        return self.start_watching_resource(
+            gdrive_resource_id=gdrive_resource_id_to_watch,
+            resource_type=resource_type_to_watch, # Pass the type
+            webhook_base_url=None # Let start_watching_resource use default/ENV
+        );
+    }
+
+    can list_active_watches() -> List[Dict] {
+        return [
+            {
+                "jiva_channel_uuid": j_uuid,
+                "gdrive_id_watched": info.get("gdrive_id_watched"),
+                "type": info.get("type"),
+                "google_channel_id": info.get("google_channel_id"),
+                "expires_at_iso": datetime.fromtimestamp(info.get("expiration_ms", 0)/1000, tz=timezone.utc).isoformat()
+            } for (j_uuid, info) in self.active_watch_channels.items()
+        ];
+    }
+
+    can pulse() {
+        self.logger.debug(f"Pulse: Checking {len(self.active_watch_channels)} GDrive watches.");
+        current_time_ms = int(datetime.now(timezone.utc).timestamp() * 1000);
+        renew_limit_ms = current_time_ms + (self.renew_threshold_hours * 3600 * 1000);
+        jiva_uuids_to_check = list(self.active_watch_channels.keys());
+        for jiva_uuid in jiva_uuids_to_check {
+            watch_info = self.active_watch_channels.get(jiva_uuid);
+            if (not watch_info) { continue; }
+            if (watch_info.get("expiration_ms", 0) < renew_limit_ms) {
+                self.logger.info(f"Watch {jiva_uuid} (GDrive ID: {watch_info.get('gdrive_id_watched')}) needs renewal.");
+                self.renew_watch_channel(jiva_channel_uuid=jiva_uuid);
+            }
+        }
+        self.logger.debug("Pulse check for GDrive watches complete.");
+    }
+
+    can recover_watches(webhook_base_url: Optional[str] = None) -> Dict {
+        self.logger.info(f"Recovering watches for {len(self.watched_gdrive_resources)} DAF-configured resources.");
+        results = {"succeeded": [], "failed": []};
+        base_url = webhook_base_url if webhook_base_url else self.default_webhook_base_url;
+        if (not base_url) {
+             base_url = os.environ.get('JIVAS_BASE_URL');
+             if (not base_url) {
+                self.logger.error("Recovery failed: Webhook base URL not configured.");
+                return {"status": "failed", "message": "Webhook base URL not configured."};
+             }
+             if (not self.default_webhook_base_url) { self.default_webhook_base_url = base_url; }
+        }
+
+        for res_conf in self.watched_gdrive_resources {
+            gdrive_id = res_conf.get("gdrive_id");
+            res_type = res_conf.get("type", "file"); # Default to 'file' if type not specified
+            if (gdrive_id) {
+                if (not any([info.get("gdrive_id_watched") == gdrive_id for info in self.active_watch_channels.values()])) {
+                    start_res = self.start_watching_resource(gdrive_id, res_type, base_url);
+                    if (start_res.get("status") == "succeeded") {
+                        results["succeeded"].append({"gdrive_id": gdrive_id, "jiva_channel_uuid": start_res.get("jiva_channel_uuid")});
+                    } else {
+                        results["failed"].append({"gdrive_id": gdrive_id, "reason": start_res.get("message")});
+                    }
+                } else {
+                     results["succeeded"].append({"gdrive_id": gdrive_id, "status": "already_active"});
+                }
+            }
+        }
+        return results;
+    }
+
+    can start_pulse_scheduler() {
+        if (pulse_action := self.get_agent().get_actions().get(action_label="PulseAction")) {
+            action_node_label = self.label; # Get the label of this action instance
+            interval_string = f'every({self.pulse_interval_seconds}).seconds';
+
+            # Remove existing schedule for this action label first to prevent duplicates
+            pulse_action.remove_schedule(action_label=action_node_label); # Use action_label here
+
+            # Add new schedule
+            pulse_action.add_schedule(
+                action_label=action_node_label, # Pass this action's label
+                interval_spec=interval_string   # Pass the interval string
+            );
+            self.logger.info(f"Pulse schedule added for '{action_node_label}' with interval '{interval_string}'.");
+        } else {
+            self.logger.warning("PulseAction not found or not enabled. Cannot start GDrive watch renewal pulse.");
+        }
+    }
+
+    can stop_pulse_scheduler() {
+        if (pulse_action := self.get_agent().get_actions().get(action_label="PulseAction")) {
+            action_node_label = self.label; # Get the label of this action instance
+            pulse_action.remove_schedule(action_label=action_node_label); # Use action_label here
+            self.logger.info(f"Pulse schedule removed for '{action_node_label}'.");
+        }
+    }
+
+    can ingest_drive_items(drive_ids: List[str], item_type: str = "file", user_metadata: Optional[dict] = None) -> dict {
+        results = {"succeeded_deepdoc": [], "failed_deepdoc": [], "job_ids": [], "watches_managed": []};
+        drive_handler = self.get_drive_handler();
+        deepdoc_action = self.get_deepdoc_action();
+        if (not drive_handler or not deepdoc_action) {
+            msg = "GDrive Handler or DeepDoc action not available.";
+            self.logger.error(msg);
+            results["failed_deepdoc"] = [{"id": id, "reason": msg} for id in drive_ids];
+            return results;
+        }
+
+        files_for_deepdoc_payload = []; # List of dicts for DeepDoc: {"name", "content", "type"}
+        files_processed_details = [];   # List of dicts: {"id", "name", "mimeType", "parents", "original_item_type"}
+                                        # original_item_type is 'file' or 'folder' if drive_id was a folder
+
+        for gdrive_id_or_folder_id in drive_ids {
+            original_item_type_for_id = item_type; # 'file' or 'folder' as passed to this ability
+
+            current_files_for_id = []; # Files from this specific gdrive_id_or_folder_id
+            if (original_item_type_for_id == "file") {
+                file_meta = drive_handler.get_file_metadata(file_id=gdrive_id_or_folder_id);
+                if ("error" not in file_meta) {
+                    current_files_for_id.append({
+                        "id": gdrive_id_or_folder_id, "name": file_meta.get("name"),
+                        "mimeType": file_meta.get("mimeType"), "parents": file_meta.get("parents", [])
+                    });
+                } else { results["failed_deepdoc"].append({"id": gdrive_id_or_folder_id, "reason": f"Metadata error: {file_meta['error']}"}); continue; }
+            } elif (original_item_type_for_id == "folder") {
+                folder_contents = drive_handler.list_files_in_folder(folder_id=gdrive_id_or_folder_id);
+                if ("error" not in folder_contents) {
+                    for item_meta in folder_contents {
+                        if (not item_meta.get("mimeType", "").startswith("application/vnd.google-apps.folder")) {
+                             current_files_for_id.append({
+                                "id": item_meta["id"], "name": item_meta.get("name"),
+                                "mimeType": item_meta.get("mimeType"), "parents": item_meta.get("parents", [])
+                            });
+                        }
+                    }
+                } else { results["failed_deepdoc"].append({"id": gdrive_id_or_folder_id, "reason": f"Folder list error: {folder_contents['error']}"}); continue; }
+            }
+
+            for file_detail in current_files_for_id {
+                content_data = drive_handler.download_file_content(file_id=file_detail["id"]);
+                if (isinstance(content_data, dict) and "error" in content_data) {
+                    results["failed_deepdoc"].append({"id": file_detail["id"], "reason": f"Download error: {content_data['error']}"});
+                    continue;
+                }
+                files_for_deepdoc_payload.append({"name": file_detail["name"], "content": content_data, "type": file_detail["mimeType"]});
+
+                # Store details including the original item type (folder or file) that led to this file
+                # and the specific parent folder ID of this file.
+                file_parent_folder_id = file_detail["parents"][0] if file_detail["parents"] else "root";
+
+                # processed_details =
+                files_processed_details.append({
+                    "id": file_detail["id"], "name": file_detail["name"],
+                    "parent_folder_id_of_file": file_parent_folder_id,
+                    "source_gdrive_id_was_folder": (original_item_type_for_id == "folder"),
+                    "source_gdrive_id": gdrive_id_or_folder_id,  # The ID that was passed in drive_ids list
+                    **(user_metadata or {})  # Unpacks user_metadata if it exists, otherwise empty dict
+                });
+            }
+        }
+
+        if (files_for_deepdoc_payload) {
+            # Prepare metadatas (one per file in files_for_deepdoc_payload)
+            # This assumes files_for_deepdoc_payload and files_processed_details are in the same order
+            # OR we need to match them by name/id if DeepDoc requires aligned metadata
+            deepdoc_metadatas = [];
+            for i in range(len(files_for_deepdoc_payload)) {
+                processed_file_detail = files_processed_details[i]; # Assuming alignment
+                metadata = {
+                    "source_system": "google_drive",
+                    "google_drive_file_id": processed_file_detail["id"],
+                    "google_drive_filename": processed_file_detail["name"],
+                    # "google_drive_mimetype": files_for_deepdoc_payload[i]["type"], # Redundant but we can still add since DeepDoc action takes type
+                    "google_drive_folder_id": processed_file_detail["parent_folder_id_of_file"]
+                };
+                if (user_metadata) { metadata.update(user_metadata); }
+                deepdoc_metadatas.append(metadata);
+            }
+
+            # log metadata before
+            self.logger.warning(f"MetaDataBefore: {deepdoc_metadatas}");
+
+            job_id = deepdoc_action.queue_deepdoc_job(files=files_for_deepdoc_payload, metadatas=deepdoc_metadatas, callback_url="");
+            if (job_id) {
+                results["job_ids"].append(job_id);
+                for detail in files_processed_details { # Iterate over successfully prepared files
+                    results["succeeded_deepdoc"].append({"id": detail["id"], "name": detail["name"], "job_id": job_id});
+
+                    # Log Metadata After
+                    self.logger.warning(f"MetaDataBefore: {detail}");
+
+                    # --- WATCHER LOGIC POST-INGESTION ---
+                    if (self.auto_watch_on_ingest) {
+                        watch_target_id = "";
+                        watch_type = "";
+                        if (detail["source_gdrive_id_was_folder"]) { # If the original item was a folder
+                            watch_target_id = detail["source_gdrive_id"]; # Watch the folder
+                            watch_type = "folder";
+                        } else { # Original item was a file (standalone)
+                            watch_target_id = detail["id"]; # Watch the file itself
+                            watch_type = "file";
+                        }
+
+                        # Check if a watch for this target_id already exists to avoid duplicates
+                        already_watching_target = False;
+                        for (j_uuid, existing_watch) in self.active_watch_channels.items() {
+                            if (existing_watch.get("gdrive_id_watched") == watch_target_id) {
+                                already_watching_target = True;
+                                results["watches_managed"].append({
+                                    "gdrive_id": watch_target_id, "type": watch_type,
+                                    "status": "already_active", "jiva_channel_uuid": j_uuid
+                                });
+                                break;
+                            }
+                        }
+
+                        if (not already_watching_target) {
+                            watch_result = self.start_watching_resource(
+                                gdrive_resource_id=watch_target_id,
+                                resource_type=watch_type, # Pass the determined type
+                                webhook_base_url=None
+                            );
+                            results["watches_managed"].append({
+                                "gdrive_id": watch_target_id, "type": watch_type,
+                                "status": watch_result.get("status"),
+                                "jiva_channel_uuid": watch_result.get("jiva_channel_uuid"),
+                                "message": watch_result.get("message")
+                            });
+                        }
+                    }
+                }
+            } else { # DeepDoc job queuing failed
+                 for detail in files_processed_details {
+                    results["failed_deepdoc"].append({"id": detail["id"], "name": detail["name"], "reason": "DeepDoc job queuing failed"});
+                }
+            }
+        }
+        return results;
+    }
+
+    can remove_drive_item_from_vector_store(google_drive_file_id: str) -> Dict {
+        result = {"status": "failed", "message": "", "watch_management_status": "not_attempted"};
+        deepdoc_action = self.get_deepdoc_action();
+        if (not deepdoc_action) { result["message"] = "DeepDoc action not found."; return result;}
+
+        all_doc_entries = deepdoc_action.get_doc_entries();
+        found_entry_metadata = None;
+        job_id_to_delete = None;
+        filename_to_delete = None;
+
+        for entry in all_doc_entries {
+            entry_meta = entry.get("metadata", {});
+            if (entry_meta.get("google_drive_file_id") == google_drive_file_id) {
+                found_entry_metadata = entry_meta;
+                job_id_to_delete = entry.get("job_id");
+                filename_to_delete = entry.get("filename");
+                break;
+            }
+        }
+
+        if (found_entry_metadata and job_id_to_delete) {
+            if (deepdoc_action.delete_doc_entry(job_id=job_id_to_delete, filename=filename_to_delete)) {
+                result["status"] = "succeeded";
+                result["message"] = f"Deleted GDrive ID {google_drive_file_id} from DeepDoc.";
+
+                # --- WATCHER LOGIC POST-DELETION (SINGLE FILE) ---
+                if (self.auto_watch_on_ingest) {
+                    parent_folder_id = found_entry_metadata.get("google_drive_folder_id");
+
+                    if (parent_folder_id and parent_folder_id != "root" and parent_folder_id != "none") {
+                        # File was part of a watched folder
+                        # Check if other files from this folder still exist in DeepDoc
+                        other_files_in_folder_exist = False;
+                        current_all_docs = deepdoc_action.get_doc_entries(); # Re-fetch
+                        for doc_entry in current_all_docs {
+                            if (doc_entry.get("metadata", {}).get("google_drive_folder_id") == parent_folder_id) {
+                                other_files_in_folder_exist = True;
+                                break;
+                            }
+                        }
+                        if (not other_files_in_folder_exist) {
+                            # Last file in folder deleted, stop watching the folder
+                            jiva_uuid_folder_watch = None;
+                            for (j_uuid, w_info) in self.active_watch_channels.items() {
+                                if (w_info.get("gdrive_id_watched") == parent_folder_id and w_info.get("type") == "folder") {
+                                    jiva_uuid_folder_watch = j_uuid; break;
+                                }
+                            }
+                            if (jiva_uuid_folder_watch) {
+                                stop_res = self.stop_watching_resource(jiva_uuid_folder_watch, False);
+                                result["watch_management_status"] = f"Folder {parent_folder_id} watch stop: {stop_res.get('status')}";
+                            } else { result["watch_management_status"] = "Folder watch not found for emptied folder."; }
+                        } else { result["watch_management_status"] = "Folder still has items; folder watch retained."; }
+                    } else {
+                        # Standalone file deleted, stop watching the file itself
+                        jiva_uuid_file_watch = None;
+                        for (j_uuid, w_info) in self.active_watch_channels.items() {
+                            if (w_info.get("gdrive_id_watched") == google_drive_file_id and w_info.get("type") == "file") {
+                                jiva_uuid_file_watch = j_uuid; break;
+                            }
+                        }
+                        if (jiva_uuid_file_watch) {
+                            stop_res = self.stop_watching_resource(jiva_uuid_file_watch, False);
+                            result["watch_management_status"] = f"File {google_drive_file_id} watch stop: {stop_res.get('status')}";
+                        } else { result["watch_management_status"] = "File watch not found for deleted file."; }
+                    }
+                }
+            } else { result["message"] = f"DeepDoc failed to delete {google_drive_file_id}."; }
+        } else { result["message"] = f"GDrive ID {google_drive_file_id} not found in DeepDoc."; }
+        return result;
+    }
+
+    can remove_drive_folder_from_vector_store(google_drive_folder_id: str) -> Dict {
+        results = {"deleted_files": [], "failed_to_delete_from_deepdoc": [], "watches_stopped": [], "watches_failed_to_stop": [], "message": ""};
+        deepdoc_action = self.get_deepdoc_action();
+        if (not deepdoc_action) {
+            results["message"] = "DeepDoc action not found.";
+            return results;
+        }
+
+        all_doc_entries = deepdoc_action.get_doc_entries();
+        files_in_folder_to_process = []; # Renamed to avoid confusion with files_to_process in ingest
+
+        for entry in all_doc_entries {
+            if (entry.get("metadata", {}).get("google_drive_folder_id") == google_drive_folder_id) {
+                files_in_folder_to_process.append({
+                    "job_id": entry["job_id"],
+                    "filename": entry["filename"], # DeepDoc internal filename
+                    "gdrive_file_id": entry.get("metadata", {}).get("google_drive_file_id", "unknown")
+                });
+            }
+        }
+
+        if (not files_in_folder_to_process) {
+            results["message"] = f"No DeepDoc entries found for Google Drive folder ID: {google_drive_folder_id}.";
+            self.logger.info(results["message"]);
+            return results;
+        }
+
+        self.logger.info(f"Found {len(files_in_folder_to_process)} files from GDrive folder {google_drive_folder_id} to remove from vector store.");
+
+        gdrive_ids_successfully_deleted_from_deepdoc = [];
+
+        for item_to_delete in files_in_folder_to_process {
+            if (deepdoc_action.delete_doc_entry(job_id=item_to_delete["job_id"], filename=item_to_delete["filename"])) {
+                results["deleted_files"].append(item_to_delete["gdrive_file_id"]); # List of GDrive IDs successfully deleted from DeepDoc
+                gdrive_ids_successfully_deleted_from_deepdoc.append(item_to_delete["gdrive_file_id"]);
+            } else {
+                results["failed_to_delete_from_deepdoc"].append(item_to_delete["gdrive_file_id"]);
+            }
+        }
+
+        # If the entire folder's content representation in DeepDoc is removed, stop watching the folder.
+        if (self.auto_watch_on_ingest) {
+            jiva_uuid_folder_watch = None;
+            for (j_uuid, watch_info) in self.active_watch_channels.items() {
+                if (watch_info.get("gdrive_id_watched") == google_drive_folder_id and watch_info.get("type") == "folder") {
+                    jiva_uuid_folder_watch = j_uuid;
+                    break;
+                }
+            }
+            if (jiva_uuid_folder_watch) {
+                stop_res = self.stop_watching_resource(jiva_channel_uuid=jiva_uuid_folder_watch, initiated_by_user=False);
+                results["watch_management_status"] = f"Folder {google_drive_folder_id} watch stop: {stop_res.get('status')}";
+            } else {
+                results["watch_management_status"] = f"No active watch found for folder {google_drive_folder_id}.";
+            }
+        }
+
+        if (results["failed_to_delete_from_deepdoc"]) {
+            results["message"] = f"Attempted to remove folder {google_drive_folder_id} from DeepDoc. Succeeded for {len(results['deleted_files'])} files, failed for {len(results['failed_to_delete_from_deepdoc'])} files.";
+        } else {
+            results["message"] = f"Successfully requested removal of all {len(results['deleted_files'])} files from folder {google_drive_folder_id} via DeepDoc.";
+        }
+        if (results["watches_failed_to_stop"]) {
+            results["message"] += f" Auto-unwatch: succeeded for {len(results['watches_stopped'])} files, failed for {len(results['watches_failed_to_stop'])} files.";
+        } elif (results["watches_stopped"]) {
+             results["message"] += f" Auto-unwatch: successfully stopped watches for {len(results['watches_stopped'])} files.";
+        }
+
+
+        self.logger.info(results["message"]);
+        return results;
+    }
+
+    can _get_gdrive_id_from_resource_uri(resource_uri: str) -> Optional[str] {
+        # Helper to extract the GDrive ID from X-Goog-Resource-URI
+        # Example URI: https://www.googleapis.com/drive/v3/files/FILE_ID?alt=json
+        # Example URI for changes API: https://www.googleapis.com/drive/v3/changes/CHANGE_ID?alt=json (less useful here)
+        try {
+            parsed_url = urlparse(resource_uri);
+            path_parts = parsed_url.path.strip('/').split('/');
+            # Look for 'files' or 'folders' segment, ID is usually after it.
+            # This is a bit heuristic. Google's docs should be checked for canonical parsing.
+            if ("files" in path_parts) {
+                id_index = path_parts.index("files") + 1;
+                if (id_index < len(path_parts)) {
+                    return path_parts[id_index];
+                }
+            }
+             # Add similar logic for 'folders' if needed, though watch is on fileId
+        } except Exception as e {
+            self.logger.error(f"Error parsing GDrive resource URI '{resource_uri}': {e}");
+        }
+        return None;
+    }
+
+    can process_drive_notification(headers: Dict, body_str: str) {
+        drive_handler = self.get_drive_handler();
+        if (not drive_handler) {
+            return {"status": "failed", "message": "Google Drive Handler not available."};
+        }
+
+        google_channel_id = headers.get('X-Goog-Channel-ID');
+        resource_state = headers.get('X-Goog-Resource-State');
+        google_resource_id_header = headers.get('x-goog-resource-id');
+        # Changed header gives hints like 'content,children' or 'properties'
+        google_changed_header = headers.get('X-Goog-Changed', '');
+        # Resource URI of the item that *actually changed* (could be a file within a watched folder)
+        changed_resource_uri = headers.get('X-Goog-Resource-URI');
+
+        self.logger.info(f"GDrive Notification: GoogleChannelID={google_channel_id}, State={resource_state}, ChangedURI={changed_resource_uri}, GoogleChangedHeader={google_changed_header}");
+
+        jiva_uuid_found = None;
+        watch_info = None;
+        for (j_uuid, w_info) in self.active_watch_channels.items() {
+            if (w_info.get("google_channel_id") == google_channel_id) {
+                jiva_uuid_found = j_uuid;
+                watch_info = w_info;
+                break;
+            }
+        }
+
+        if (not watch_info) {
+            self.logger.warning(f"Received notification for unknown or stopped Google Channel ID: {google_channel_id}. It might have been stopped/expired.");
+            # Google might send a final notification after a channel is stopped.
+            # Attempt to tell Google to stop it again if it's truly unknown, to be safe, though it might 404.
+            if (google_channel_id and google_resource_id_header) {
+                    drive_handler.stop_channel(channel_id=google_channel_id, resource_id=google_resource_id_header);
+            }
+            return;
+        }
+
+        # This is the GDrive ID we set up the watch on (could be a file or a folder)
+        watched_gdrive_id = watch_info.get("gdrive_id_watched");
+        watched_type = watch_info.get("type"); # 'file' or 'folder'
+
+        # --- Handle different resource states ---
+        if (resource_state == "sync") {
+            self.logger.info(f"Sync notification for watch {jiva_uuid_found} on {watched_gdrive_id}.");
+            return;
+        }
+
+        # log type and other stuff needed for debugging
+        self.logger.info(f"Watch Type: {watched_type}");
+
+        # grab the change now and log
+        (new_changes, page_token) = drive_handler.get_latest_changes(page_token=self.page_token);
+
+        # log responses for debugging
+        self.logger.info(f"Last Page Token: {page_token}, Last Drive Change {new_changes}");
+
+        # set changes
+        changes = new_changes if new_changes else [];
+
+        # set page token
+        self.page_token = page_token;
+
+        # process changes
+        for changed_gdrive_resource in changes {
+            # log initial resource state
+            self.logger.info(f"Resource State: {resource_state} {changed_gdrive_resource.get('file', {})} {changed_gdrive_resource.get('file', {}).get('trashed')}");
+
+            # Determine the ID of the specific file/item that changed, from the changes
+            changed_gdrive_file_id = changed_gdrive_resource.get('fileId');
+            resource_state = "trash" if changed_gdrive_resource.get('file', {}).get('trashed') else "change";
+
+            self.logger.info(f"Resource State: {resource_state}");
+
+            if (not changed_gdrive_file_id) {
+                self.logger.error(f"Could not extract changed GDrive File ID from changes: {changed_gdrive_resource}. Aborting processing for this notification.");
+                continue;
+            }
+
+            if (resource_state in ["trash", "remove", "trashed"]) {
+                self.logger.info(f"'{resource_state}' notification for item {changed_gdrive_file_id} (watched: {watched_gdrive_id} as {watched_type})");
+
+                # Remove the specific changed item from DeepDoc
+                self.remove_drive_item_from_vector_store(google_drive_file_id=changed_gdrive_file_id); # This will handle its own watch logic
+
+                # If the watched item was a FOLDER and this deleted file was the LAST one in it (in DeepDoc)
+                if (watched_type == "folder" and changed_gdrive_file_id != watched_gdrive_id) { # Check if not the folder itself
+                    # Re-check if the folder is now empty in DeepDoc
+                    if (not self._is_folder_still_represented_in_deepdoc(watched_gdrive_id)) {
+                        self.logger.info(f"Watched folder {watched_gdrive_id} is now empty in DeepDoc. Stopping watch on folder.");
+                        self.stop_watching_resource(jiva_channel_uuid=jiva_uuid_found, initiated_by_user=False);
+                    }
+                } elif (watched_type == "file" and changed_gdrive_file_id == watched_gdrive_id) {
+                    # The watched standalone file itself was deleted. remove_drive_item_from_vector_store should have stopped its watch.
+                    # If not, ensure it's stopped here (though it might be redundant).
+                    if (jiva_uuid_found in self.active_watch_channels) { # Check if stop_watching_resource inside remove didn't already get it
+                        self.logger.info(f"Ensuring watch for deleted standalone file {watched_gdrive_id} is stopped.");
+                        self.stop_watching_resource(jiva_channel_uuid=jiva_uuid_found, initiated_by_user=False);
+                    }
+                }
+                continue;
+            }
+
+            if (resource_state == "change" or headers.get('X-Goog-Changed')) {
+                self.logger.info(f"'change' notification for item {changed_gdrive_file_id} (watched: {watched_gdrive_id} as {watched_type})");
+
+                if (watched_type == "folder") {
+                    # If a folder is watched, a "change" could be:
+                    # 1. Metadata change on the folder itself (changed_gdrive_file_id == watched_gdrive_id)
+                    # 2. A file within the folder changed (changed_gdrive_file_id != watched_gdrive_id)
+                    # 3. A new file was added to the folder (Google might report change on folder, or directly on new file if that's how watches work)
+
+                    # For simplicity, if a folder watch gets a 'change', we assume a file within it changed or was added.
+                    # The most robust way is to re-ingest the specific 'changed_gdrive_file_id'.
+                    # If 'changed_gdrive_file_id' is the folder ID itself, one might re-scan the folder for new/modified files.
+                    # For now, let's assume 'change' on a folder watch implies we should re-ingest the 'changed_gdrive_file_id' if it's a folder item.
+
+                    if (drive_handler) {
+                        meta = drive_handler.get_file_metadata(file_id=changed_gdrive_file_id);
+                        if ("error" not in meta and not meta.get("mimeType", "").startswith("application/vnd.google-apps.folder")) {
+                            self.logger.info(f"File {changed_gdrive_file_id} in watched folder {watched_gdrive_id} changed. Re-ingesting file.");
+                            self.remove_drive_item_from_vector_store(google_drive_file_id=changed_gdrive_file_id);
+
+                            # log details
+                            self.logger.warning(f"Logging Important stuff to debug why ingesting is creating new watcher {watched_gdrive_id}");
+                            self.ingest_drive_items(drive_ids=[changed_gdrive_file_id], item_type="file", user_metadata={"trigger": "webhook_folder_watch_change", "source_gdrive_id": watched_gdrive_id, "google_drive_folder_id": watched_gdrive_id, "source_gdrive_id_was_folder": True});
+                        } elif ("error" in meta) {
+                            self.logger.error(f"Could not get metadata for changed item {changed_gdrive_file_id} in watched folder.");
+                        } else { # It's the folder itself or another sub-folder that changed.
+                            self.logger.info(f"Change detected on folder {changed_gdrive_file_id} (possibly watched folder {watched_gdrive_id} or a subfolder). Consider re-scanning for new/modified files if deeper sync is needed.");
+                            # Potentially trigger a full re-scan and ingest of the watched_gdrive_id if changed_gdrive_file_id == watched_gdrive_id
+                            # For now, if it's the folder itself, we might just log or do nothing further beyond specific file changes.
+                            # If X-Goog-Changed indicates 'children', a re-list and diff would be ideal.
+                            # Current simplified: If it's a file, ingest. If it's the folder, log.
+                        }
+                    }
+                } elif (watched_type == "file") { # Standalone file watch
+                    if (changed_gdrive_file_id == watched_gdrive_id) {
+                        self.logger.info(f"Watched file {watched_gdrive_id} changed. Re-ingesting.");
+                        self.remove_drive_item_from_vector_store(google_drive_file_id=watched_gdrive_id);
+                        self.ingest_drive_items(drive_ids=[watched_gdrive_id], item_type="file", user_metadata={"trigger": "webhook_file_watch_change"});
+                    } else {
+                        self.logger.warning(f"Change notification for {changed_gdrive_file_id} but was watching {watched_gdrive_id}. Mismatch?");
+                    }
+                }
+                continue;
+            }
+            self.logger.warning(f"Unhandled GDrive notification state '{resource_state}' for watch {jiva_uuid_found}.");
+        }
+
+    }
+
+    can _is_folder_still_represented_in_deepdoc(folder_gdrive_id: str) -> bool {
+        # Helper to check if any files from a given folder_gdrive_id are still in DeepDoc
+        deepdoc_action = self.get_deepdoc_action();
+        if (not deepdoc_action) { return False; } # Assume not, if DeepDoc is unavailable
+
+        all_docs = deepdoc_action.get_doc_entries();
+        for doc in all_docs {
+            if (doc.get("metadata", {}).get("google_drive_folder_id") == folder_gdrive_id) {
+                return True; # Found at least one file from this folder
+            }
+        }
+        return False; # No files from this folder found
+    }
+
+    can healthcheck() -> Union[bool, Dict] {
+        drive_handler = self.get_drive_handler();
+        if (not drive_handler) {
+            return { "status": False, "message": "GDrive Handler failed to initialize.", "severity": "error"};
+        }
+        deepdoc_action = self.get_deepdoc_action();
+        if (not deepdoc_action) {
+            return { "status": False, "message": f"DeepDocClientAction ('{self.deepdoc_action_label}') not found.", "severity": "error"};
+        }
+        # Add check for webhook base URL if auto-watch is intended via DAF
+        if (self.watched_gdrive_resources and not self.default_webhook_base_url and not os.environ.get('JIVAS_BASE_URL')) {
+             self.logger.warning("watched_gdrive_resources are configured, but no webhook base URL (DAF/ENV). Auto-recovery might fail.");
+        }
+        try {
+            folder_to_test = self.default_folder_id if self.default_folder_id else "root";
+            test_list = drive_handler.list_files_in_folder(folder_id=folder_to_test, page_size=1);
+            if ("error" in test_list) {
+                return { "status": False, "message": f"GDrive API error: {test_list['error']}", "severity": "error"};
+            }
+            return True;
+        } except Exception as e {
+            return { "status": False, "message": f"GDrive healthcheck exception: {e}", "severity": "error"};
+        }
+    }
+
+    can list_gdrive_folder_contents(folder_id: str) -> List {
+        drive_handler = self.get_drive_handler();
+        if (not drive_handler) { return [{"error": "Drive Handler not ready"}]; }
+        return drive_handler.list_files_in_folder(folder_id=folder_id if folder_id else self.default_folder_id);
+    }
+
+    can get_ingested_documents_from_drive() -> List {
+        deepdoc_action = self.get_deepdoc_action();
+        if (not deepdoc_action) { return [{"error": "DeepDoc action not found."}]; }
+        all_docs = deepdoc_action.get_doc_entries();
+        gdrive_docs = [doc for doc in all_docs if doc.get("metadata", {}).get("source_system") == "google_drive"];
+        return gdrive_docs;
+    }
+}

--- a/deepdoc_google_drive_action/drive_monitor/README.md
+++ b/deepdoc_google_drive_action/drive_monitor/README.md
@@ -1,0 +1,116 @@
+# Google Drive Resource Monitoring Sandbox - Setup Guide
+
+This sandbox allows you to test Google Drive resource monitoring using service accounts. It specifically focuses on watching files and folders and handling deletion events automatically.
+
+## Prerequisites
+
+1. A Google Cloud project with the Google Drive API enabled
+2. A service account with appropriate permissions
+3. A publicly accessible server to receive webhooks (or use ngrok for testing)
+4. Python 3.6+ installed
+
+## Setup Instructions
+
+### 1. Create a Service Account
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+2. Navigate to **IAM & Admin** > **Service Accounts**
+3. Click **Create Service Account**
+4. Enter a name and description for your service account
+5. Grant the service account the **Drive API > Drive API File Scope** permission
+6. Click **Create Key** and select JSON
+7. Save the key file as `service-account-key.json` in the same directory as the sandbox code
+
+### 2. Set Up Webhook Endpoint
+
+The sandbox requires a publicly accessible HTTPS endpoint to receive notifications. For development, you can use [ngrok](https://ngrok.com/):
+
+```bash
+# Install ngrok if you haven't already
+pip install pyngrok
+
+# Start ngrok to expose your local Flask server
+ngrok http 8080
+```
+
+Update the `WEBHOOK_URL` in the code with your ngrok URL (or your permanent webhook URL).
+
+### 3. Share Drive Resources with the Service Account
+
+For the service account to monitor resources:
+
+1. Get the service account email from the service-account-key.json file
+2. Share the Google Drive files/folders you want to monitor with this email address
+3. Grant at least "Viewer" permission
+
+### 4. Install Dependencies
+
+```bash
+pip install flask google-api-python-client google-auth-httplib2 google-auth-oauthlib pyopenssl
+```
+
+### 5. Run the Sandbox
+
+```bash
+python drive_monitor_sandbox.py
+```
+
+## Using the Sandbox
+
+### Start Watching a Resource
+
+Use the `/api/watch` endpoint:
+
+```bash
+curl -X POST http://localhost:8080/api/watch \
+  -H "Content-Type: application/json" \
+  -d '{"resource_id": "your-drive-file-or-folder-id", "resource_type": "file"}'
+```
+
+### List Active Channels
+
+```bash
+curl http://localhost:8080/api/channels
+```
+
+### Stop a Specific Channel
+
+```bash
+curl -X POST http://localhost:8080/api/stop \
+  -H "Content-Type: application/json" \
+  -d '{"channel_id": "the-channel-id-to-stop"}'
+```
+
+### Clean Up Expired or Invalid Channels
+
+```bash
+curl -X POST http://localhost:8080/api/cleanup
+```
+
+## Monitoring Events
+
+The sandbox logs all notifications to `drive_monitor.log`. You can monitor this file to see events in real-time:
+
+```bash
+tail -f drive_monitor.log
+```
+
+## Key Features
+
+1. **Automatic Channel Cleanup**: When a resource is deleted or moved to trash, the corresponding notification channel is automatically stopped
+2. **Webhook Receiver**: Processes incoming notifications from Google Drive API
+3. **Channel Management**: Track active notification channels and their expiration
+4. **Resource Verification**: Periodically checks if monitored resources still exist
+
+## Testing Scenarios
+
+1. **File Update**: Edit a monitored file and save it
+2. **File Deletion**: Delete a monitored file
+3. **Folder Changes**: Add or remove files from a monitored folder
+4. **Permission Changes**: Change sharing settings for a monitored resource
+
+## Notes
+
+- Notification channels expire after 1 day (maximum allowed by the Google Drive API for files)
+- The sandbox includes a cleanup routine to remove expired channels
+- For production use, implement proper authentication for the API endpoints

--- a/deepdoc_google_drive_action/drive_monitor/call.py
+++ b/deepdoc_google_drive_action/drive_monitor/call.py
@@ -1,0 +1,16 @@
+"""Test Watch resource API call to the dev tunnel."""
+
+import json
+
+import requests
+
+url = "https://f3tvj55t-5000.use.devtunnels.ms/api/watch"
+
+payload = json.dumps(
+    {"resource_type": "folder", "resource_id": "1B3J83l7uMsmlho_tabJ_QSQnO1HTLwWd"}
+)
+headers = {"Content-Type": "application/json"}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)

--- a/deepdoc_google_drive_action/drive_monitor/channels.py
+++ b/deepdoc_google_drive_action/drive_monitor/channels.py
@@ -1,0 +1,14 @@
+"""Test list channels API call to the dev tunnel."""
+
+import json
+
+import requests
+
+url = "https://f3tvj55t-5000.use.devtunnels.ms/api/channels"
+
+payload = json.dumps({})
+headers = {"Content-Type": "application/json"}
+
+response = requests.request("GET", url, headers=headers, data=payload)
+
+print(response.text)

--- a/deepdoc_google_drive_action/drive_monitor/list_active_drive_channels.py
+++ b/deepdoc_google_drive_action/drive_monitor/list_active_drive_channels.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Google Drive Notification Channels Lister
+
+This script lists all active notification channels for Google Drive resources.
+"""
+
+import argparse
+import json
+import logging
+from typing import Any, Optional
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# Replace with your service account file path or info
+SERVICE_ACCOUNT_INFO = {
+    "type": "",
+    "project_id": "",
+    "private_key_id": "",
+    "private_key": "",  # Handle escaped newlines from YAML
+    "client_email": "",
+    "client_id": "",
+    "auth_uri": "",
+    "token_uri": "",
+    "auth_provider_x509_cert_url": "",
+    "client_x509_cert_url": "",
+    "universe_domain": "",
+}  # Dictionary represention your service account key file
+# SERVICE_ACCOUNT_INFO = {...}  # Your service account JSON data
+
+
+def get_credentials() -> service_account.Credentials:
+    """Load service account credentials"""
+    try:
+        credentials = service_account.Credentials.from_service_account_info(
+            SERVICE_ACCOUNT_INFO, scopes=["https://www.googleapis.com/auth/drive"]
+        )
+        # Alternatively, use this if you have the service account info in code
+        # credentials = service_account.Credentials.from_service_account_info(
+        #     SERVICE_ACCOUNT_INFO,
+        #     scopes=['https://www.googleapis.com/auth/drive']
+        # )
+        return credentials
+    except Exception as e:
+        logger.error(f"Failed to load credentials: {e}")
+        return None
+
+
+def get_drive_service() -> Optional[Any]:
+    """Create a Drive API service"""
+    credentials = get_credentials()
+    if not credentials:
+        return None
+
+    try:
+        service = build("drive", "v3", credentials=credentials)
+        return service
+    except Exception as e:
+        logger.error(f"Failed to build Drive service: {e}")
+        return None
+
+
+def list_active_channels() -> Optional[dict]:
+    """List all active notification channels for the authenticated service account"""
+    service = get_drive_service()
+    if not service:
+        logger.error("Failed to create Drive service")
+        return None
+
+    try:
+        # Try to get all active channels
+        # Note: Google Drive API doesn't have a direct method to list channels
+        # We need to use the channels.list method under the Drive API
+
+        # Unfortunately, there's no direct API method to list all active channels
+        # The best practice is to maintain your own database of active channels
+        logger.info(
+            "Google Drive API doesn't provide a direct way to list all active channels."
+        )
+        logger.info("Checking for channels in local storage...")
+
+        # Try to read stored channels from a file
+        try:
+            with open("active_channels.json", "r") as f:
+                active_channels = json.load(f)
+                logger.info(f"Found {len(active_channels)} channels in local storage")
+                return active_channels
+        except FileNotFoundError:
+            logger.warning("No local active_channels.json file found")
+        except json.JSONDecodeError:
+            logger.error("Error parsing active_channels.json")
+
+        logger.info(
+            "To properly track channels, store channel information when you create them"
+        )
+        return {}
+    except Exception as e:
+        logger.error(f"Error listing channels: {e}")
+        return None
+
+
+def get_channel_status(channel_id: str, resource_id: str) -> dict:
+    """
+    Check if a specific channel is still active
+
+    Args:
+        channel_id: The ID of the channel
+        resource_id: The resource ID this channel is monitoring
+
+    Returns:
+        Dictionary with status information
+    """
+    service = get_drive_service()
+    if not service:
+        return {"status": "unknown", "error": "Failed to create Drive service"}
+
+    # Unfortunately, there's no direct API method to get the status of a specific channel
+    # The best approach is to try to stop the channel and see if it succeeds
+
+    logger.info(f"Checking status for channel {channel_id} on resource {resource_id}")
+
+    # If you want to verify if the channel is still active, you'd need to attempt
+    # a stop operation, which would be destructive if you just want to check status
+
+    # For this script, we'll just return what we know about the channel
+    return {
+        "channel_id": channel_id,
+        "resource_id": resource_id,
+        "status": "presumed active",
+        "note": "Google Drive API doesn't provide a method to check channel status without stopping it",
+    }
+
+
+def list_watched_files() -> list:
+    """List files being watched based on stored channels"""
+    active_channels = list_active_channels()
+    if not active_channels:
+        return []
+
+    service = get_drive_service()
+    if not service:
+        return []
+
+    watched_files = []
+    for channel_id, channel_info in active_channels.items():
+        try:
+            resource_id = channel_info.get("resource_id")
+            if not resource_id:
+                continue
+
+            file_info = (
+                service.files()
+                .get(fileId=resource_id, fields="id, name, mimeType, modifiedTime")
+                .execute()
+            )
+
+            watched_files.append(
+                {
+                    "file_id": file_info.get("id"),
+                    "name": file_info.get("name"),
+                    "type": file_info.get("mimeType"),
+                    "last_modified": file_info.get("modifiedTime"),
+                    "channel_id": channel_id,
+                    "expiration": channel_info.get("expiration"),
+                }
+            )
+        except Exception as e:
+            logger.warning(f"Failed to get info for file {resource_id}: {e}")
+
+    return watched_files
+
+
+def main() -> None:
+    """Main function to handle command line arguments and execute the script"""
+
+    parser = argparse.ArgumentParser(
+        description="List Google Drive notification channels"
+    )
+    parser.add_argument("--json", action="store_true", help="Output in JSON format")
+    parser.add_argument("--check-file", action="store_true", help="Check watched files")
+    args = parser.parse_args()
+
+    # Get active channels
+    active_channels = list_active_channels()
+
+    if args.json:
+        print(json.dumps(active_channels, indent=2))
+    else:
+        print("\n=== Active Google Drive Notification Channels ===\n")
+        if not active_channels:
+            print("No active channels found or unable to retrieve channels.")
+            print(
+                "Note: Google Drive API doesn't provide a direct method to list all channels."
+            )
+            print("Channels must be tracked when they are created.")
+        else:
+            for channel_id, channel_info in active_channels.items():
+                print(f"Channel ID: {channel_id}")
+                print(f"Resource ID: {channel_info.get('resource_id', 'unknown')}")
+                print(f"Resource Type: {channel_info.get('resource_type', 'unknown')}")
+                print(f"Expiration: {channel_info.get('expiration', 'unknown')}")
+                print(f"Created At: {channel_info.get('created_at', 'unknown')}")
+                print("-" * 40)
+
+    # If requested, check watched files
+    if args.check_file:
+        watched_files = list_watched_files()
+        if args.json:
+            print(json.dumps(watched_files, indent=2))
+        else:
+            print("\n=== Files Being Watched ===\n")
+            if not watched_files:
+                print("No watched files found or unable to retrieve file information.")
+            else:
+                for file in watched_files:
+                    print(f"File Name: {file.get('name', 'unknown')}")
+                    print(f"File ID: {file.get('file_id', 'unknown')}")
+                    print(f"File Type: {file.get('type', 'unknown')}")
+                    print(f"Last Modified: {file.get('last_modified', 'unknown')}")
+                    print(f"Channel ID: {file.get('channel_id', 'unknown')}")
+                    print(f"Channel Expiration: {file.get('expiration', 'unknown')}")
+                    print("-" * 40)
+
+
+if __name__ == "__main__":
+    main()

--- a/deepdoc_google_drive_action/drive_monitor/main.py
+++ b/deepdoc_google_drive_action/drive_monitor/main.py
@@ -1,0 +1,368 @@
+"""Driver Monitor Sandbox Server"""
+
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from flask import Flask, jsonify, request
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.FileHandler("drive_monitor.log"), logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+# Flask app for webhook receiver
+app = Flask(__name__)
+
+# Global variables
+active_channels = {}  # Dictionary to track active notification channels
+SERVICE_ACCOUNT_INFO = {
+    "type": "",
+    "project_id": "",
+    "private_key_id": "",
+    "private_key": "",  # Handle escaped newlines from YAML
+    "client_email": "",
+    "client_id": "",
+    "auth_uri": "",
+    "token_uri": "",
+    "auth_provider_x509_cert_url": "",
+    "client_x509_cert_url": "",
+    "universe_domain": "",
+}  # Dictionary represention your service account key file
+WEBHOOK_URL = "https://example.com/notifications"  # Replace with your domain
+
+
+# Load service account credentials
+def get_credentials() -> service_account.Credentials:
+    """Get service account credentials
+
+    Returns:
+        Credentials: Service account credentials object
+    """
+
+    try:
+        credentials = service_account.Credentials.from_service_account_info(
+            SERVICE_ACCOUNT_INFO, scopes=["https://www.googleapis.com/auth/drive"]
+        )
+        return credentials
+    except Exception as e:
+        logger.error(f"Failed to load credentials: {e}")
+        return None
+
+
+# Create Drive service
+def get_drive_service() -> Optional[Any]:
+    """Create a Drive API service"""
+
+    credentials = get_credentials()
+    if not credentials:
+        return None
+
+    try:
+        service = build("drive", "v3", credentials=credentials)
+        return service
+    except Exception as e:
+        logger.error(f"Failed to build Drive service: {e}")
+        return None
+
+
+# Create a notification channel to watch a resource (file or folder)
+def create_watch_channel(
+    resource_id: str, resource_type: str = "file"
+) -> Optional[dict]:
+    """
+    Creates a notification channel for a Drive resource
+
+    Args:
+        resource_id: The ID of the Drive resource to monitor
+        resource_type: Either "file" or "folder" (both are treated as files in the API)
+
+    Returns:
+        The notification channel information if successful, None otherwise
+    """
+
+    service = get_drive_service()
+    if not service:
+        return None
+
+    channel_id = str(uuid.uuid4())
+    channel_token = f"resource={resource_id}-{int(time.time())}"
+
+    # Set expiration to 1 day from now (in milliseconds)
+    expiration = int((datetime.now() + timedelta(days=1)).timestamp() * 1000)
+
+    # Create channel request body
+    channel_body = {
+        "id": channel_id,
+        "type": "web_hook",
+        "address": WEBHOOK_URL,
+        "token": channel_token,
+        "expiration": expiration,
+    }
+
+    try:
+        # Watch the resource
+        response = (
+            service.files().watch(fileId=resource_id, body=channel_body).execute()
+        )
+
+        # Store channel information for later management
+        active_channels[channel_id] = {
+            "resource_id": resource_id,
+            "resource_type": resource_type,
+            "channel_id": channel_id,
+            "resource_uri": response.get("resourceUri"),
+            "expiration": expiration,
+            "created_at": datetime.now().isoformat(),
+        }
+
+        logger.info(
+            f"Created watch channel for {resource_type} {resource_id}: {channel_id}"
+        )
+        return response
+    except HttpError as e:
+        logger.error(
+            f"Failed to create watch channel for {resource_type} {resource_id}: {e}"
+        )
+        return None
+
+
+# Stop a notification channel
+def stop_watch_channel(channel_id: str) -> bool:
+    """
+    Stops an active notification channel
+
+    Args:
+        channel_id: The ID of the channel to stop
+
+    Returns:
+        True if successful, False otherwise
+    """
+
+    service = get_drive_service()
+    if not service:
+        return False
+
+    logger.warning(f"Channel {active_channels} {channel_id}")
+
+    # channel_info = {"id": "60aed5c0-0f97-4307-87f2-ac18b47f41f0", "resource_id": "qbIPQ8g2L141USt9S1U9N5rkryQ"}
+    # active_channels[channel_id] = channel_info
+
+    if channel_id not in active_channels:
+        logger.warning(f"Channel {channel_id} not found in active channels")
+        return False
+
+    channel_info = active_channels[channel_id]
+
+    logger.warning(f"channel_info {channel_info}")
+
+    stop_body = {"id": channel_id, "resourceId": channel_info["resource_id"]}
+
+    try:
+        service.channels().stop(body=stop_body).execute()
+        logger.info(
+            f"Stopped watch channel {channel_id} for resource {channel_info['resource_id']}"
+        )
+
+        # Remove from active channels
+        del active_channels[channel_id]
+        return True
+    except HttpError as e:
+        logger.error(f"Failed to stop watch channel {channel_id}: {e}")
+        return False
+
+
+# List all active channels
+def list_active_channels() -> dict[Any, Any]:
+    """Returns all currently active notification channels"""
+
+    return active_channels
+
+
+# Check if a resource still exists
+def check_resource_exists(resource_id: str) -> bool:
+    """
+    Checks if a Drive resource still exists
+
+    Args:
+        resource_id: The ID of the resource to check
+
+    Returns:
+        True if the resource exists, False otherwise
+    """
+
+    service = get_drive_service()
+    if not service:
+        return False
+
+    try:
+        # Try to get metadata for the resource
+        service.files().get(fileId=resource_id, fields="id").execute()
+        return True
+    except HttpError as e:
+        if e.resp.status == 404:
+            # Resource not found
+            logger.info(f"Resource {resource_id} no longer exists")
+            return False
+        else:
+            logger.error(f"Error checking resource {resource_id}: {e}")
+            # For other errors, assume resource still exists
+            return True
+
+
+# Clean up expired or invalid channels
+def cleanup_channels() -> int:
+    """Checks all active channels and removes those that are expired or have deleted resources"""
+
+    channels_to_remove = []
+
+    for channel_id, channel_info in active_channels.items():
+        # Check if resource still exists
+        if not check_resource_exists(channel_info["resource_id"]):
+            logger.info(
+                f"Resource {channel_info['resource_id']} no longer exists, removing channel {channel_id}"
+            )
+            stop_watch_channel(channel_id)
+            channels_to_remove.append(channel_id)
+            continue
+
+        # Check if channel has expired
+        expiration = channel_info["expiration"]
+        current_time = int(datetime.now().timestamp() * 1000)
+        if current_time > expiration:
+            logger.info(f"Channel {channel_id} has expired, stopping it")
+            stop_watch_channel(channel_id)
+            channels_to_remove.append(channel_id)
+
+    # Remove channels from the active_channels dictionary
+    for channel_id in channels_to_remove:
+        if channel_id in active_channels:
+            del active_channels[channel_id]
+
+    return len(channels_to_remove)
+
+
+# Flask routes for webhook receiver and API
+@app.route("/notifications", methods=["POST"])
+def receive_notification() -> tuple[Any, int]:
+    """Webhook endpoint to receive Drive change notifications"""
+
+    # Extract headers
+    channel_id = request.headers.get("X-Goog-Channel-ID")
+    resource_id = request.headers.get("X-Goog-Resource-ID")
+    resource_state = request.headers.get("X-Goog-Resource-State")
+    channel_token = request.headers.get("X-Goog-Channel-Token")
+    changed = request.headers.get("X-Goog-Changed", "")
+    message_number = request.headers.get("X-Goog-Message-Number")
+
+    # Create a dictionary with all request information
+    request_data = {
+        "timestamp": datetime.now().isoformat(),
+        "method": request.method,
+        "url": request.url,
+        "path": request.path,
+        "endpoint": request.endpoint,
+        "headers": dict(request.headers),
+        "args": dict(request.args),
+        "form": dict(request.form),
+        "cookies": dict(request.cookies),
+        "remote_addr": request.remote_addr,
+    }
+
+    notification_data = {
+        "channel_id": channel_id,
+        "resource_id": resource_id,
+        "resource_state": resource_state,
+        "channel_token": channel_token,
+        "changed_properties": changed.split(",") if changed else [],
+        "message_number": message_number,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    logger.info(f"Received notification: {json.dumps(notification_data)}")
+    logger.info(f"Full notification: {request_data}")
+
+    # Handle resource deletion
+    if resource_state in ["trash", "remove"]:
+        logger.info(
+            f"Resource {resource_id} was {resource_state}d, stopping channel {channel_id}"
+        )
+        # Find all channels watching this resource
+        channels_to_stop = [
+            cid
+            for cid, info in active_channels.items()
+            if info["resource_id"] == resource_id
+        ]
+
+        for cid in channels_to_stop:
+            stop_watch_channel(cid)
+
+    # Return success to Google's notification service
+    return "", 200
+
+
+@app.route("/api/channels", methods=["GET"])
+def get_channels() -> tuple[Any, int]:
+    """API endpoint to list all active channels"""
+
+    return jsonify(active_channels)
+
+
+@app.route("/api/watch", methods=["POST"])
+def watch_resource() -> tuple[Any, int]:
+    """API endpoint to start watching a resource"""
+
+    data = request.json
+    resource_id = data.get("resource_id")
+    resource_type = data.get("resource_type", "file")
+
+    if not resource_id:
+        return jsonify({"error": "resource_id is required"}), 400
+
+    result = create_watch_channel(resource_id, resource_type)
+    if result:
+        return jsonify(result), 201
+    else:
+        return jsonify({"error": "Failed to create watch channel"}), 500
+
+
+@app.route("/api/stop", methods=["POST"])
+def stop_channel() -> tuple[Any, int]:
+    """API endpoint to stop a channel"""
+
+    data = request.json
+    channel_id = data.get("channel_id")
+
+    if not channel_id:
+        return jsonify({"error": "channel_id is required"}), 400
+
+    result = stop_watch_channel(channel_id)
+    if result:
+        return jsonify({"success": True}), 200
+    else:
+        return jsonify({"error": "Failed to stop channel"}), 500
+
+
+@app.route("/api/cleanup", methods=["POST"])
+def cleanup() -> tuple[Any, int]:
+    """API endpoint to clean up expired channels"""
+
+    count = cleanup_channels()
+    return jsonify({"removed_channels_count": count}), 200
+
+
+if __name__ == "__main__":
+    # On startup, clean up any expired channels
+    cleanup_channels()
+
+    # Start the Flask server
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/deepdoc_google_drive_action/drive_monitor/stop.py
+++ b/deepdoc_google_drive_action/drive_monitor/stop.py
@@ -1,0 +1,14 @@
+"""Test Script used to stop a channel."""
+
+import json
+
+import requests
+
+url = "https://f3tvj55t-5000.use.devtunnels.ms/api/stop"
+
+payload = json.dumps({"channel_id": "60aed5c0-0f97-4307-87f2-ac18b47f41f0"})
+headers = {"Content-Type": "application/json"}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)

--- a/deepdoc_google_drive_action/gdrive_notification_receiver_walker.jac
+++ b/deepdoc_google_drive_action/gdrive_notification_receiver_walker.jac
@@ -1,0 +1,41 @@
+import:py logging;
+import:py json; # If body is JSON
+import:py from logging { Logger }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+walker gdrive_notification_receiver_walker :interact_graph_walker: {
+    static has logger:Logger = logging.getLogger(__name__);
+
+    has headers:dict = {};
+    has params:dict = {}; # For query params if any
+    has body:dict = {};   # Raw request body
+    has response:dict = {"status": "received"}; # Default response to Google
+
+    can on_agent with Agent entry {
+        self.logger.warning(f"Headers: {self.headers}, Params: {self.params}, Body: {self.body}");
+        # Basic validation
+        if (not self.headers.get('X-Goog-Channel-ID') or not self.headers.get('X-Goog-Resource-ID')) {
+            self.logger.warning("Received GDrive notification without required headers. Ignoring.");
+
+            Jac.get_context().status = 400; # Bad Request
+            disengage;
+        }
+
+        # Find the DeepDocGoogleDriveAction
+        if (dd_gdrive_action := here.get_actions().get(action_label='DeepDocGoogleDriveAction')) {
+            # Delegate processing to the action
+            dd_gdrive_action.process_drive_notification(
+                headers=self.headers,
+                body_str=self.body # Pass raw body string
+            );
+            Jac.get_context().status = 200; # Acknowledge receipt
+        } else {
+            self.logger.error("DeepDocGoogleDriveAction not found or not enabled. Cannot process GDrive notification.");
+            Jac.get_context().status = 500; # Internal Server Error
+        }
+        disengage; # Walker's job is done after delegation
+    }
+}

--- a/deepdoc_google_drive_action/get_ingested_gdrive_docs_walker.jac
+++ b/deepdoc_google_drive_action/get_ingested_gdrive_docs_walker.jac
@@ -1,0 +1,23 @@
+# --- Walkers for DeepDocGoogleDriveAction UI interaction ---
+
+import:py from typing { List, Dict, Optional }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+
+# Walker to get documents ingested from Google Drive (from DeepDoc manifest)
+walker get_ingested_gdrive_docs_walker :interact_graph_walker: {
+    has response: List = []; # Will be a list of dicts or list containing an error dict
+
+    can on_agent with Agent entry {
+        visit [-->](`?Actions);
+    }
+    can on_actions with Actions entry {
+        visit [-->](`?Action)(?enabled==True)(?label=='DeepDocGoogleDriveAction');
+    }
+    can on_google_drive_action with Action entry {
+        self.response = here.get_ingested_documents_from_drive();
+    }
+}

--- a/deepdoc_google_drive_action/info.yaml
+++ b/deepdoc_google_drive_action/info.yaml
@@ -1,0 +1,59 @@
+package:
+  name: jivas/deepdoc_google_drive_action
+  author: AA
+  architype: DeepDocGoogleDriveAction
+  version: 0.0.3 # Latest
+  meta:
+    title: DeepDoc Google Drive Integration Action (with Watcher)
+    description: Ingests, manages, and watches documents/folders from Google Drive using DeepDoc client for vector storage and processing. Reacts to GDrive changes.
+    group: integration
+    type: action
+  config:
+    singleton: true
+    # --- Watcher Configuration (New for 0.0.2) ---
+    # List of GDrive resources the action should persistently try to watch.
+    # Each item is a dictionary, e.g., {"gdrive_id": "your_folder_or_file_id"}
+    # The 'type' ("file" or "folder") is for future use/clarity, not currently used by recovery logic.
+    watched_gdrive_resources: []
+
+    # --- New for v0.0.3 ---
+    auto_watch_on_ingest: true # Default value
+    # Publicly accessible base URL of your Jiva instance for Google Drive webhooks.
+    # If empty, action will try to use JIVAS_BASE_URL environment variable.
+    default_webhook_base_url: ""
+
+    # How often (in seconds) the pulse ability should run to check and renew watch channels.
+    pulse_interval_seconds: 3600
+
+    # Renew watch channels if their expiration is within this many hours.
+    renew_threshold_hours: 6
+
+    # --- Original Configuration ---
+    # Default Google Drive folder ID to operate on if none is specified in walker calls.
+    default_folder_id: ""
+
+    # The label of the DeepDocClientAction instance used by this agent.
+    deepdoc_action_label: "DeepDocClientAction"
+
+    # Google API scopes. For watching and reading, 'drive.readonly' is usually enough.
+    # If Drive modifications were added, this would need to expand.
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
+
+    # --- Service Account Credentials (MUST be configured in agent DAF) ---
+    info_type: "service_account"
+    project_id: ""
+    private_key_id: ""
+    private_key: "" # Multiline YAML string, ensure '\n' are literal or use '|-'
+    client_email: ""
+    client_id: ""
+    auth_uri: "https://accounts.google.com/o/oauth2/auth"
+    token_uri: "https://oauth2.googleapis.com/token"
+    auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs"
+    client_x509_cert_url: "" # e.g., "https://www.googleapis.com/robot/v1/metadata/x509/your-client-email.iam.gserviceaccount.com"
+    universe_domain: "googleapis.com"
+
+  dependencies:
+    jivas: ^2.0.0
+    actions:
+      jivas/deepdoc_client_action: ^0.0.1 # Critical dependency for DeepDoc operations
+      jivas/pulse_action: ^0.0.1         # Also Critical for scheduling watch renewal

--- a/deepdoc_google_drive_action/ingest_gdrive_items_walker.jac
+++ b/deepdoc_google_drive_action/ingest_gdrive_items_walker.jac
@@ -1,0 +1,32 @@
+# --- Walkers for DeepDocGoogleDriveAction UI interaction ---
+
+import:py from typing { List, Dict, Optional }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+
+# Walker to trigger ingestion of Drive items
+walker ingest_gdrive_items_walker :interact_graph_walker: {
+    has drive_ids: List[str] = [];
+    has item_type: str = "file"; # "file" or "folder"
+    has user_metadata: Optional[Dict] = {};
+    has response: Dict = {};
+
+    can on_agent with Agent entry {
+        visit [-->](`?Actions);
+    }
+    can on_actions with Actions entry {
+        # Find the specific DeepDocGoogleDriveAction instance
+        visit [-->](`?Action)(?enabled==True)(?label=='DeepDocGoogleDriveAction'); # Assuming default label. If action was renamed please change here
+    }
+    can on_google_drive_action with Action entry {
+        # Call the ingest_drive_items ability
+        self.response = here.ingest_drive_items(
+            drive_ids=self.drive_ids,
+            item_type=self.item_type,
+            user_metadata=self.user_metadata
+        );
+    }
+}

--- a/deepdoc_google_drive_action/lib.jac
+++ b/deepdoc_google_drive_action/lib.jac
@@ -1,0 +1,9 @@
+# Imports
+include:jac deepdoc_google_drive_action;
+include:jac ingest_gdrive_items_walker;
+include:jac remove_gdrive_item_walker;
+include:jac clear_gdrive_folder_walker;
+include:jac list_gdrive_folder_contents_walker;
+include:jac get_ingested_gdrive_docs_walker;
+include:jac gdrive_notification_receiver_walker;
+include:jac manage_gdrive_watch_walker;

--- a/deepdoc_google_drive_action/list_gdrive_folder_contents_walker.jac
+++ b/deepdoc_google_drive_action/list_gdrive_folder_contents_walker.jac
@@ -1,0 +1,24 @@
+# --- Walkers for DeepDocGoogleDriveAction UI interaction ---
+
+import:py from typing { List, Dict, Optional }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+
+# Walker to list GDrive folder contents (directly from GDrive)
+walker list_gdrive_folder_contents_walker :interact_graph_walker: {
+    has folder_id: str = "";
+    has response: List = [];
+
+    can on_agent with Agent entry {
+        visit [-->](`?Actions);
+    }
+    can on_actions with Actions entry {
+        visit [-->](`?Action)(?enabled==True)(?label=='DeepDocGoogleDriveAction');
+    }
+    can on_google_drive_action with Action entry {
+        self.response = here.list_gdrive_folder_contents(folder_id=self.folder_id);
+    }
+}

--- a/deepdoc_google_drive_action/manage_gdrive_watch_walker.jac
+++ b/deepdoc_google_drive_action/manage_gdrive_watch_walker.jac
@@ -1,0 +1,53 @@
+import:py from typing { List, Dict, Optional, Literal }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+walker manage_gdrive_watch_walker :interact_graph_walker: {
+    has operation: Literal["start", "stop", "list", "renew", "recover"] = "list";
+    has gdrive_resource_id: Optional[str] = None;
+    has jiva_channel_uuid: Optional[str] = None; # Jiva's internal UUID for the watch
+    has webhook_base_url: Optional[str] = None; # Needed for start, e.g., "https://your-jiva-instance.com"
+    has resource_type: Optional[str] = None; # resource type to be monitored
+
+    has response: Dict = {};
+
+    can on_agent with Agent entry {
+        visit [-->](`?Actions);
+    }
+    can on_actions with Actions entry {
+        visit [-->](`?Action)(?enabled==True)(?label=='DeepDocGoogleDriveAction');
+    }
+    can on_google_drive_action with Action entry {
+        if (self.operation == "start") {
+            if (self.gdrive_resource_id and self.webhook_base_url) {
+                self.response = here.start_watching_resource(
+                    gdrive_resource_id=self.gdrive_resource_id,
+                    webhook_base_url=self.webhook_base_url,
+                    resource_type=self.resource_type
+                );
+            } else {
+                self.response = {"status": "failed", "message": "gdrive_resource_id and webhook_base_url are required for start operation."};
+            }
+        } elif (self.operation == "stop") {
+            if (self.jiva_channel_uuid) {
+                self.response = here.stop_watching_resource(jiva_channel_uuid=self.jiva_channel_uuid, initiated_by_user=True);
+            } else {
+                self.response = {"status": "failed", "message": "jiva_channel_uuid is required for stop operation."};
+            }
+        } elif (self.operation == "list") {
+            self.response = {"active_watches": here.list_active_watches()};
+        } elif (self.operation == "renew") { # For manual testing/triggering
+            if (self.jiva_channel_uuid) {
+                self.response = here.renew_watch_channel(jiva_channel_uuid=self.jiva_channel_uuid);
+            } else {
+                self.response = {"status": "failed", "message": "jiva_channel_uuid is required for renew operation."};
+            }
+        } elif (self.operation == "recover") {
+             self.response = here.recover_watches(webhook_base_url=self.webhook_base_url); # webhook_base_url might be needed if stored globally
+        } else {
+            self.response = {"status": "failed", "message": f"Unknown operation: {self.operation}"};
+        }
+    }
+}

--- a/deepdoc_google_drive_action/modules/google_drive_handler.py
+++ b/deepdoc_google_drive_action/modules/google_drive_handler.py
@@ -1,0 +1,331 @@
+"""Google Drive API handler for file operations."""
+
+import io
+import logging
+from typing import Any, Optional
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleDriveHandler:
+    """Google Drive API handler for file operations."""
+
+    def __init__(self, credentials_info: dict, scopes: list) -> None:
+        """
+        Initializes the Google Drive API service.
+        :param credentials_info: Dictionary containing service account credentials.
+        :param scopes: List of scopes for API access.
+        """
+        try:
+            self.creds = service_account.Credentials.from_service_account_info(
+                credentials_info, scopes=scopes
+            )
+            self.service = build("drive", "v3", credentials=self.creds)
+            logger.info("Google Drive API service initialized successfully.")
+        except Exception as e:
+            logger.error(f"Failed to initialize Google Drive API service: {e}")
+            self.service = None
+            self.creds = None  # Ensure creds is also None if service init fails
+
+    def is_healthy(self) -> bool:
+        """Checks if the service object was initialized."""
+        return self.service is not None
+
+    def list_files_in_folder(
+        self,
+        folder_id: str,
+        page_size: int = 100,
+        fields: str = "nextPageToken, files(id, name, mimeType, webViewLink, modifiedTime, parents)",
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """Lists files and folders within a given folder ID."""
+
+        if not self.is_healthy():
+            return {"error": "Google Drive service not initialized."}
+        items = []
+        page_token = None
+        try:
+            while True:
+                response = (
+                    self.service.files()
+                    .list(
+                        q=f"'{folder_id}' in parents and trashed=false",  # Exclude trashed files
+                        pageSize=page_size,
+                        fields=fields,
+                        pageToken=page_token,
+                    )
+                    .execute()
+                )
+                items.extend(response.get("files", []))
+                page_token = response.get("nextPageToken")
+                if page_token is None:
+                    break
+            logger.info(f"Found {len(items)} items in folder '{folder_id}'.")
+            return items
+        except HttpError as error:
+            logger.error(
+                f"An API error occurred while listing files in folder {folder_id}: {error}"
+            )
+            return {"error": str(error)}
+        except Exception as e:
+            logger.error(f"Unexpected error listing files in folder {folder_id}: {e}")
+            return {"error": str(e)}
+
+    def get_file_metadata(
+        self,
+        file_id: str,
+        fields: str = "id, name, mimeType, webViewLink, parents, modifiedTime",
+    ) -> dict[str, Any]:
+        """Gets metadata for a specific file ID."""
+        if not self.is_healthy():
+            return {"error": "Google Drive service not initialized."}
+        try:
+            file_meta = (
+                self.service.files().get(fileId=file_id, fields=fields).execute()
+            )
+            return file_meta
+        except HttpError as error:
+            logger.error(
+                f"An API error occurred while getting metadata for file {file_id}: {error}"
+            )
+            return {"error": str(error)}
+        except Exception as e:
+            logger.error(f"Unexpected error getting metadata for file {file_id}: {e}")
+            return {"error": str(e)}
+
+    def download_file_content(self, file_id: str) -> bytes | dict[str, Any]:
+        """Downloads file content by file ID."""
+        if not self.is_healthy():
+            return {"error": "Google Drive service not initialized."}
+        try:
+            request = self.service.files().get_media(fileId=file_id)
+            fh = io.BytesIO()
+            downloader = MediaIoBaseDownload(fh, request)
+            done = False
+            while not done:
+                status, done = downloader.next_chunk()
+                logger.debug(
+                    f"Download progress for {file_id}: {int(status.progress() * 100)}%"
+                )
+            fh.seek(0)
+            logger.info(f"Successfully downloaded content for file ID: {file_id}")
+            return fh.read()  # Returns bytes
+        except HttpError as error:
+            logger.error(
+                f"An API error occurred while downloading file {file_id}: {error}"
+            )
+            return {"error": str(error)}
+        except Exception as e:
+            logger.error(f"Unexpected error downloading file {file_id}: {e}")
+            return {"error": str(e)}
+
+    def delete_drive_file_permanently(self, file_id: str) -> bool | dict[str, Any]:
+        """Permanently deletes a file from Google Drive."""
+        if not self.is_healthy():
+            return {"error": "Google Drive service not initialized."}
+        try:
+            self.service.files().delete(fileId=file_id).execute()
+            logger.info(f"Successfully deleted file {file_id} from Google Drive.")
+            return True
+        except HttpError as error:
+            logger.error(
+                f"An API error occurred while deleting file {file_id} from Drive: {error}"
+            )
+            return {"error": str(error)}
+        except Exception as e:
+            logger.error(f"Unexpected error deleting file {file_id} from Drive: {e}")
+            return {"error": str(e)}
+
+    def watch_file(
+        self,
+        file_id: str,
+        channel_id: str,
+        channel_token: str,
+        webhook_url: str,
+        expiration_ms: int,
+    ) -> dict[str, Any]:
+        """Creates a watch on a file."""
+        if not self.is_healthy():
+            return {"error": "Google Drive service not initialized."}
+
+        channel_body = {
+            "id": channel_id,  # Your UUID for the channel
+            "type": "web_hook",
+            "address": webhook_url,  # Your publicly accessible webhook URL
+            "token": channel_token,  # Optional: Your token to verify notifications
+            "expiration": str(
+                expiration_ms
+            ),  # Expiration time in milliseconds since epoch
+        }
+        try:
+            logger.info(
+                f"Attempting to watch file {file_id} with channel_id {channel_id}, webhook {webhook_url}, expiration {expiration_ms}"
+            )
+            response = (
+                self.service.files()
+                .watch(
+                    fileId=file_id,
+                    body=channel_body,
+                    supportsAllDrives=True,  # Add if dealing with Shared Drives
+                )
+                .execute()
+            )
+            logger.info(f"Successfully created watch for file {file_id}: {response}")
+            return response  # Contains 'id', 'resourceId', 'resourceUri', 'expiration' from Google
+        except HttpError as error:
+            logger.error(f"API error creating watch for file {file_id}: {error}")
+            return {
+                "error": str(error),
+                "details": error.resp.status,
+                "reason": error._get_reason(),
+            }
+        except Exception as e:
+            logger.error(f"Unexpected error creating watch for file {file_id}: {e}")
+            return {"error": str(e)}
+
+    def stop_channel(self, channel_id: str, resource_id: str) -> dict[str, Any]:
+        """Stops a notification channel."""
+        if not self.is_healthy():
+            return {"error": "Google Drive service not initialized."}
+
+        channel_body = {"id": channel_id, "resourceId": resource_id}
+        try:
+            logger.info(
+                f"Attempting to stop channel: ID={channel_id}, ResourceID={resource_id}"
+            )
+            self.service.channels().stop(body=channel_body).execute()
+            logger.info(
+                f"Successfully stopped channel: ID={channel_id}, ResourceID={resource_id}"
+            )
+            return {"status": "success"}
+        except HttpError as error:
+            logger.error(f"API error stopping channel {channel_id}: {error}")
+            return {
+                "error": str(error),
+                "details": error.resp.status,
+                "reason": error._get_reason(),
+            }
+        except Exception as e:
+            logger.error(f"Unexpected error stopping channel {channel_id}: {e}")
+            return {"error": str(e)}
+
+    def get_initial_start_page_token(self, drive_id: str = "") -> Optional[str]:
+        """
+        Gets the starting page token for listing future changes.
+        This token represents the current state of the account.
+        :param drive_id: Optional ID of the Shared Drive to get the start page token for.
+                         If None, gets for the user's account.
+        :return: The startPageToken string or None if an error occurs.
+        """
+        if not self.is_healthy():
+            logger.error(
+                "Google Drive service not initialized. Cannot get start page token."
+            )
+            return None
+        try:
+            request_args: dict[str, Any] = {}
+            if drive_id:
+                request_args["driveId"] = drive_id
+                request_args["supportsAllDrives"] = (
+                    True  # Required if driveId is specified
+                )
+
+            token_response = (
+                self.service.changes().getStartPageToken(**request_args).execute()
+            )
+            start_page_token = token_response.get("startPageToken")
+            logger.info(
+                f"Successfully retrieved initial startPageToken: {start_page_token}"
+            )
+            return start_page_token
+        except HttpError as error:
+            logger.error(
+                f"An API error occurred while getting start page token: {error}"
+            )
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error getting start page token: {e}")
+            return None
+
+    def get_latest_changes(
+        self,
+        page_token: str,
+        drive_id: str = "",
+        fields: str = "nextPageToken, newStartPageToken, changes(fileId, time, removed, teamDriveId, driveId, file(id, name, mimeType, parents, modifiedTime, trashed))",
+    ) -> tuple[Optional[list[dict[str, Any]]], str]:
+        """
+        Lists all changes since the last provided page token.
+        Handles pagination internally to retrieve all changes in the current batch.
+        :param page_token: The pageToken from which to retrieve changes (initially from get_initial_start_page_token()
+                           or newStartPageToken from a previous call to this method).
+        :param drive_id: Optional ID of the Shared Drive to list changes for.
+        :param fields: The fields to include in the change resources.
+        :return: A tuple: (list_of_changes, new_start_page_token_for_next_call).
+                 Returns (None, page_token) if an error occurs, so the original token can be reused for a retry.
+        """
+        if not self.is_healthy():
+            logger.error("Google Drive service not initialized. Cannot get changes.")
+            return None, page_token  # Return original token for potential retry
+
+        all_changes = []
+        current_page_token = page_token
+        new_start_page_token_for_next_call = (
+            page_token  # Default to original if no changes or error
+        )
+
+        try:
+            while current_page_token is not None:
+                request_args = {
+                    "pageToken": current_page_token,
+                    "spaces": "drive",  # Important: 'drive' space includes My Drive and Shared Drives
+                    "fields": fields,
+                    "includeRemoved": True,  # Typically you want to know about removals
+                    "supportsAllDrives": True,  # Recommended for comprehensive change tracking
+                }
+                if drive_id:
+                    request_args["driveId"] = drive_id
+
+                logger.debug(f"Fetching changes with pageToken: {current_page_token}")
+                response = self.service.changes().list(**request_args).execute()
+
+                changes_in_page = response.get("changes", [])
+                all_changes.extend(changes_in_page)
+                logger.info(
+                    f"Fetched {len(changes_in_page)} changes in this page. Total so far: {len(all_changes)}."
+                )
+
+                if "nextPageToken" in response and response["nextPageToken"]:
+                    current_page_token = response.get("nextPageToken")
+                    logger.debug(
+                        f"More changes available, next page token: {current_page_token}"
+                    )
+                else:
+                    # No more pages in this batch, get the token for the *next* poll
+                    new_start_page_token_for_next_call = response.get(
+                        "newStartPageToken"
+                    )
+                    logger.info(
+                        f"End of changes for this batch. New startPageToken for next poll: {new_start_page_token_for_next_call}"
+                    )
+                    current_page_token = ""  # Exit loop
+
+            return all_changes, new_start_page_token_for_next_call
+
+        except HttpError as error:
+            logger.error(
+                f"An API error occurred while listing changes: {error}. Last used pageToken: {page_token}"
+            )
+            # Return the original page_token so the caller can decide to retry with it
+            return None, page_token
+        except Exception as e:
+            logger.error(
+                f"Unexpected error listing changes: {e}. Last used pageToken: {page_token}"
+            )
+            return None, page_token
+
+    # You can add more methods like create_folder, upload_file if needed for other functionalities
+    # For now, focusing on reading for ingestion.

--- a/deepdoc_google_drive_action/remove_gdrive_item_walker.jac
+++ b/deepdoc_google_drive_action/remove_gdrive_item_walker.jac
@@ -1,0 +1,26 @@
+# --- Walkers for DeepDocGoogleDriveAction UI interaction ---
+
+import:py from typing { List, Dict, Optional }
+import:jac from jivas.agent.action.interact_graph_walker { interact_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+
+
+# Walker to remove a single Drive item from the vector store
+walker remove_gdrive_item_walker :interact_graph_walker: {
+    has google_drive_file_id: str = "";
+    has response: Dict = {};
+
+    can on_agent with Agent entry {
+        visit [-->](`?Actions);
+    }
+    can on_actions with Actions entry {
+        visit [-->](`?Action)(?enabled==True)(?label=='DeepDocGoogleDriveAction');
+    }
+    can on_google_drive_action with Action entry {
+        self.response = here.remove_drive_item_from_vector_store(
+            google_drive_file_id=self.google_drive_file_id
+        );
+    }
+}


### PR DESCRIPTION
# DeepDoc Google Drive Integration Action (with Watcher)

## Package Information

- **Name:** jivas/deepdoc_google_drive_action
- **Author:** AA
- **Architype:** DeepDocGoogleDriveAction
- **Version:** 0.0.3

## Meta Information

- **Title:** DeepDoc Google Drive Integration Action (with Watcher)
- **Description:** Ingests, manages, and watches documents/folders from Google Drive using the DeepDoc client for vector storage and processing. Automatically reacts to changes in watched Google Drive resources.
- **Group:** integration
- **Type:** action

## Features (Version 0.0.3)

- **Google Drive Document Ingestion:**
  - Ingests individual files or all files within specified Google Drive folders.
  - Downloads content and queues it to a configured `DeepDocClientAction` for processing and vector storage.
  - Stores Google Drive metadata (file ID, folder ID, filename, MIME type) with the document in DeepDoc, ensuring correct folder association even for webhook-triggered re-ingestions.
- **Google Drive Watcher (Push Notifications):**
  - **Start/Stop Watching:** Allows starting and stopping watches on specific Google Drive files or folders.
    - **Corrected Watcher Logic (v0.0.3):** Ensures that when ingesting a folder (either initially or due to a webhook for a watched folder), a single watch is correctly established on the *folder itself*, rather than creating multiple watchers for individual files within it.
  - **Webhook Receiver:** Includes `gdrive_notification_receiver_walker` to handle incoming change notifications from Google Drive.
  - **Automatic Re-ingestion/Deletion:**
    - On "change" notification for a watched resource, automatically re-ingests the updated file/folder contents into DeepDoc.
    - On "trash" or "remove" notification, automatically removes the corresponding document(s) from DeepDoc and stops the watch if appropriate.
  - **Channel Renewal:** A `pulse` ability, schedulable via `PulseAction`, automatically renews active watch channels before they expire.
  - **Watch Recovery:** An `on_enable` hook and `recover_watches` ability attempt to re-establish watches for resources listed in the DAF configuration (`watched_gdrive_resources`) after an agent restart.
- **Vector Store Management:**
  - Remove individual Google Drive files or entire folders (and their contents) from the DeepDoc vector store, including managing associated watchers.
- **Configuration & UI:**
  - Configurable via agent DAF for Google Cloud Service Account credentials, DeepDoc action label, default GDrive folder, and comprehensive watcher settings.
  - Streamlit UI (`app/app.py`) for:
    - Managing Google Drive credentials.
    - Triggering manual ingestion.
    - Managing Google Drive watchers (start, stop, list active, trigger manual renewal/recovery).
    - Viewing and managing documents ingested from Google Drive (via DeepDoc's manifest).

## Configuration (To be set in Agent DAF context for this action)

- **`watched_gdrive_resources`** (List[Dict], default: `[]`):
  - A list of Google Drive resources that the action should persistently try to watch.
  - Each item is a dictionary, e.g., `{"gdrive_id": "your_folder_or_file_id", "type": "folder"}`. The `type` field ("file" or "folder") is now used by the watcher logic to determine how to watch the resource.
- **`default_webhook_base_url`** (str, default: `""` or `JIVAS_BASE_URL` env var):
  - Your Jiva instance's publicly accessible base URL (e.g., `https://my-jiva.example.com`). **Crucial for Google Drive to send notifications.**
- **`auto_watch_on_ingest`** (bool, default: `true`):
  - Whether to automatically attempt to start watching a GDrive resource after it has been ingested.
- **`pulse_interval_seconds`** (int, default: `3600`):
  - How often the `pulse` ability runs to check and renew watch channels.
- **`renew_threshold_hours`** (int, default: `6`):
  - If a watch channel's expiration is within this many hours, it will be renewed.
- **`default_folder_id`** (str, optional): Default Google Drive folder ID for operations if not specified.
- **`deepdoc_action_label`** (str, default: `"DeepDocClientAction"`): Label of the `DeepDocClientAction` used.
- **`scopes`** (list, default: `["https://www.googleapis.com/auth/drive.readonly"]`): Google API scopes.
- **Service Account Credentials:** (All string values, `private_key` is multiline)
  - `project_id`, `private_key_id`, `private_key`, `client_email`, `client_id`, `auth_uri`, `token_uri`, `auth_provider_x509_cert_url`, `client_x509_cert_url`, `universe_domain`.

## Core Abilities (Callable via Walkers or Internally)

- **`ingest_drive_items(drive_ids: List[str], item_type: str, user_metadata: Optional[Dict])`**: Ingests from GDrive to DeepDoc and manages `auto_watch_on_ingest`.
- **`remove_drive_item_from_vector_store(google_drive_file_id: str)`**: Removes a GDrive file from DeepDoc and its watch.
- **`remove_drive_folder_from_vector_store(google_drive_folder_id: str)`**: Removes GDrive folder contents from DeepDoc and its watch.
- **`start_watching_resource(gdrive_resource_id: str, resource_type: str, webhook_base_url: Optional[str])`**: Starts a new watch (for "file" or "folder").
- **`stop_watching_resource(jiva_channel_uuid: str, initiated_by_user: bool)`**: Stops an active watch.
- **`renew_watch_channel(jiva_channel_uuid: str)`**: Manually triggers renewal of a watch.
- **`list_active_watches()`**: Returns a list of Jiva-managed active watches.
- **`process_drive_notification(headers: Dict, body_str: str)`**: Handles GDrive webhook events.
- **`pulse()`**: Scheduled ability to renew watch channels.
- **`recover_watches(webhook_base_url: Optional[str])`**: Re-establishes watches from DAF config.
- **`healthcheck()`**: Checks GDrive/DeepDoc/Webhook URL connectivity.
- **UI Helpers:** `list_gdrive_folder_contents`, `get_ingested_documents_from_drive`.

## Walkers

- **`gdrive_notification_receiver_walker`**: Webhook endpoint for Google Drive push notifications.
- **`manage_gdrive_watch_walker`**: UI walker to start/stop/list/renew/recover watches.
- (Existing walkers for ingestion and direct management: `ingest_gdrive_items_walker`, `remove_gdrive_item_walker`, `clear_gdrive_folder_walker`, `list_gdrive_folder_contents_walker`, `get_ingested_gdrive_docs_walker`).

## Dependencies

- **Jiva Actions:**
  - `jivas/deepdoc_client_action`: For interacting with the DeepDoc service.
  - `jivas/pulse_action`: For scheduling the watch renewal `pulse`.
- **Python Libraries:**
  - `google-api-python-client` (>=2.80.0 recommended)
  - `google-auth` (>=2.14.0 recommended)
  - `google-auth-httplib2` (>=0.1.0 recommended)
  - (Ensure these are in the Jiva environment's `requirements.txt` or specified in the action's `info.yaml` pip dependencies).

## Setup Notes

1.  **Google Cloud Project:** Ensure the Google Drive API is enabled.
2.  **Service Account:** Create and download a Service Account key JSON. Configure credentials in the agent's DAF for this action.
3.  **Public Jiva URL:** The `default_webhook_base_url` (or `JIVAS_BASE_URL` env var) **must** point to your publicly accessible Jiva instance for Google to send notifications.
4.  **DAF Configuration:**
    - Populate all Google Service Account credentials.
    - Set `default_webhook_base_url`.
    - Configure `watched_gdrive_resources` with resources (and their `type`: "file" or "folder") to monitor automatically upon agent startup. Example: `{"gdrive_id": "your_id", "type": "folder"}`.
5.  **Dependent Actions:** Ensure `DeepDocClientAction` and `PulseAction` are correctly configured and enabled for the agent.
6.  **Google Drive Changes API:** This action now utilizes the `changes().watch()` and `files().watch()` API for push notifications. The `page_token` for `changes` API is managed internally to process changes since the last notification.